### PR TITLE
VPS Phase 1

### DIFF
--- a/ViroRenderer/VROARSession.h
+++ b/ViroRenderer/VROARSession.h
@@ -444,6 +444,17 @@ public:
     }
 
     /*
+     WS-D: true if the OS has only granted approximate/reduced-accuracy location
+     (iOS 14+ "Precise Location" off) and a request for temporary full accuracy
+     was denied or is unavailable. When true, horizontalAccuracy will stay at
+     the ~km scale and getEarthTrackingState() will never leave Localizing —
+     the app should surface an explicit error instead of waiting.
+     */
+    virtual bool isLocationAccuracyReduced() const {
+        return false;
+    }
+
+    /*
      Check VPS availability at the specified location.
      The callback will be called with the availability status.
      */
@@ -591,6 +602,19 @@ public:
     virtual void rvGetProject(
         const std::string& projectId,
         std::function<void(bool success, std::string jsonData, std::string error)> callback) {
+        if (callback) callback(false, "", "Not supported");
+    }
+
+    // WS-A: room/building-scale scan API — defines its own location frame
+    // instead of requiring a hand-placed anchor. rvFinishScan() is the
+    // scan-based counterpart to hostCloudAnchor(); see
+    // RVCCACloudAnchorProvider::startScan()/finishScan().
+    virtual void rvStartScan() {
+        // Default implementation does nothing
+    }
+    virtual void rvFinishScan(
+        int ttlDays,
+        std::function<void(bool success, std::string cloudAnchorId, std::string error)> callback) {
         if (callback) callback(false, "", "Not supported");
     }
 

--- a/ViroRenderer/VROARSession.h
+++ b/ViroRenderer/VROARSession.h
@@ -612,10 +612,15 @@ public:
     virtual void rvStartScan() {
         // Default implementation does nothing
     }
+    // WS-C: locationTransform is the 16 values of the VROMatrix4f used to host
+    // this scan, comma-separated, column-major (VROMatrix4f::getArray() order).
+    // Pass it straight through to rvSnapshotWorldMeshToFile() if attaching a
+    // mesh — finishScan() has no placed anchor to read a transform from.
     virtual void rvFinishScan(
         int ttlDays,
-        std::function<void(bool success, std::string cloudAnchorId, std::string error)> callback) {
-        if (callback) callback(false, "", "Not supported");
+        std::function<void(bool success, std::string cloudAnchorId,
+                            std::string locationTransformCsv, std::string error)> callback) {
+        if (callback) callback(false, "", "", "Not supported");
     }
 
     // ========================================================================

--- a/ViroRenderer/VROARWorldMesh.cpp
+++ b/ViroRenderer/VROARWorldMesh.cpp
@@ -34,6 +34,8 @@
 #include <btBulletDynamicsCommon.h>
 #include <unordered_map>
 #include <algorithm>
+#include <cstring>
+#include <cstdint>
 
 void BulletRigidBodyDeleter::operator()(btRigidBody *body) const {
     if (!body) return;
@@ -471,4 +473,141 @@ void VROARWorldMesh::debugDraw(std::shared_ptr<VROPencil> pencil) {
             trianglesDrawn++;
         }
     }
+}
+
+// ─── WS-C: mesh snapshot serialization ────────────────────────────────────────
+
+namespace {
+    constexpr uint8_t kMeshSnapshotMagic[4] = {'R', 'V', 'W', 'M'};
+    constexpr uint8_t kMeshSnapshotVersion = 1;
+
+    void appendU32(std::vector<uint8_t>& out, uint32_t v) {
+        out.push_back((uint8_t)(v & 0xFF));
+        out.push_back((uint8_t)((v >> 8) & 0xFF));
+        out.push_back((uint8_t)((v >> 16) & 0xFF));
+        out.push_back((uint8_t)((v >> 24) & 0xFF));
+    }
+
+    void appendFloat(std::vector<uint8_t>& out, float v) {
+        uint32_t bits;
+        memcpy(&bits, &v, sizeof(bits));
+        appendU32(out, bits);
+    }
+
+    void appendI32(std::vector<uint8_t>& out, int32_t v) {
+        uint32_t bits;
+        memcpy(&bits, &v, sizeof(bits));
+        appendU32(out, bits);
+    }
+
+    bool readU32(const std::vector<uint8_t>& in, size_t offset, uint32_t& out) {
+        if (offset + 4 > in.size()) return false;
+        out = (uint32_t)in[offset] | ((uint32_t)in[offset + 1] << 8) |
+              ((uint32_t)in[offset + 2] << 16) | ((uint32_t)in[offset + 3] << 24);
+        return true;
+    }
+
+    bool readFloat(const std::vector<uint8_t>& in, size_t offset, float& out) {
+        uint32_t bits;
+        if (!readU32(in, offset, bits)) return false;
+        memcpy(&out, &bits, sizeof(out));
+        return true;
+    }
+
+    bool readI32(const std::vector<uint8_t>& in, size_t offset, int32_t& out) {
+        uint32_t bits;
+        if (!readU32(in, offset, bits)) return false;
+        memcpy(&out, &bits, sizeof(out));
+        return true;
+    }
+}
+
+std::vector<uint8_t> VROARWorldMesh::serializeCurrentMesh() const {
+    if (!_currentMesh || !_currentMesh->isValid()) {
+        return {};
+    }
+
+    const std::vector<VROVector3f>& vertices    = _currentMesh->getVertices();
+    const std::vector<float>&       confidences  = _currentMesh->getConfidences();
+    const std::vector<int>&         indices      = _currentMesh->getIndices();
+
+    const uint32_t vertexCount   = (uint32_t)vertices.size();
+    const uint32_t triangleCount = (uint32_t)(indices.size() / 3);
+
+    std::vector<uint8_t> out;
+    out.reserve(13 + vertexCount * (3 * 4 + 4) + triangleCount * 3 * 4);
+
+    out.insert(out.end(), kMeshSnapshotMagic, kMeshSnapshotMagic + 4);
+    out.push_back(kMeshSnapshotVersion);
+    appendU32(out, vertexCount);
+    appendU32(out, triangleCount);
+
+    for (const VROVector3f& v : vertices) {
+        appendFloat(out, v.x);
+        appendFloat(out, v.y);
+        appendFloat(out, v.z);
+    }
+    // confidences.size() should equal vertices.size(), but guard against any
+    // mismatch rather than reading out of bounds.
+    for (uint32_t i = 0; i < vertexCount; ++i) {
+        appendFloat(out, i < confidences.size() ? confidences[i] : 1.0f);
+    }
+    for (uint32_t i = 0; i < triangleCount * 3; ++i) {
+        appendI32(out, (int32_t)indices[i]);
+    }
+
+    return out;
+}
+
+std::shared_ptr<VROARDepthMesh> VROARWorldMesh::loadMeshSnapshot(const std::vector<uint8_t>& data) {
+    if (data.size() < 13 ||
+        data[0] != kMeshSnapshotMagic[0] || data[1] != kMeshSnapshotMagic[1] ||
+        data[2] != kMeshSnapshotMagic[2] || data[3] != kMeshSnapshotMagic[3] ||
+        data[4] != kMeshSnapshotVersion) {
+        pwarn("VROARWorldMesh::loadMeshSnapshot: bad magic/version");
+        return nullptr;
+    }
+
+    uint32_t vertexCount = 0, triangleCount = 0;
+    if (!readU32(data, 5, vertexCount) || !readU32(data, 9, triangleCount)) {
+        return nullptr;
+    }
+
+    size_t offset = 13;
+    const size_t verticesBytes    = (size_t)vertexCount * 3 * 4;
+    const size_t confidencesBytes = (size_t)vertexCount * 4;
+    const size_t indicesBytes     = (size_t)triangleCount * 3 * 4;
+    if (data.size() < offset + verticesBytes + confidencesBytes + indicesBytes) {
+        pwarn("VROARWorldMesh::loadMeshSnapshot: truncated data");
+        return nullptr;
+    }
+
+    std::vector<VROVector3f> vertices;
+    vertices.reserve(vertexCount);
+    for (uint32_t i = 0; i < vertexCount; ++i) {
+        float x, y, z;
+        readFloat(data, offset, x);      offset += 4;
+        readFloat(data, offset, y);      offset += 4;
+        readFloat(data, offset, z);      offset += 4;
+        vertices.emplace_back(x, y, z);
+    }
+
+    std::vector<float> confidences;
+    confidences.reserve(vertexCount);
+    for (uint32_t i = 0; i < vertexCount; ++i) {
+        float c;
+        readFloat(data, offset, c);      offset += 4;
+        confidences.push_back(c);
+    }
+
+    std::vector<int> indices;
+    indices.reserve((size_t)triangleCount * 3);
+    for (uint32_t i = 0; i < triangleCount * 3; ++i) {
+        int32_t idx;
+        readI32(data, offset, idx);      offset += 4;
+        indices.push_back(idx);
+    }
+
+    return std::make_shared<VROARDepthMesh>(std::move(vertices), std::move(indices),
+                                             std::move(confidences), "snapshot");
 }

--- a/ViroRenderer/VROARWorldMesh.cpp
+++ b/ViroRenderer/VROARWorldMesh.cpp
@@ -522,7 +522,7 @@ namespace {
     }
 }
 
-std::vector<uint8_t> VROARWorldMesh::serializeCurrentMesh() const {
+std::vector<uint8_t> VROARWorldMesh::serializeCurrentMesh(const VROMatrix4f& locationTransform) const {
     if (!_currentMesh || !_currentMesh->isValid()) {
         return {};
     }
@@ -542,10 +542,14 @@ std::vector<uint8_t> VROARWorldMesh::serializeCurrentMesh() const {
     appendU32(out, vertexCount);
     appendU32(out, triangleCount);
 
+    // Store relative to locationTransform, not raw world space — see header
+    // doc comment: a resolve on another device has an unrelated world origin.
+    const VROMatrix4f worldToLocal = locationTransform.invert();
     for (const VROVector3f& v : vertices) {
-        appendFloat(out, v.x);
-        appendFloat(out, v.y);
-        appendFloat(out, v.z);
+        VROVector3f local = worldToLocal.multiply(v);
+        appendFloat(out, local.x);
+        appendFloat(out, local.y);
+        appendFloat(out, local.z);
     }
     // confidences.size() should equal vertices.size(), but guard against any
     // mismatch rather than reading out of bounds.
@@ -559,7 +563,8 @@ std::vector<uint8_t> VROARWorldMesh::serializeCurrentMesh() const {
     return out;
 }
 
-std::shared_ptr<VROARDepthMesh> VROARWorldMesh::loadMeshSnapshot(const std::vector<uint8_t>& data) {
+std::shared_ptr<VROARDepthMesh> VROARWorldMesh::loadMeshSnapshot(const std::vector<uint8_t>& data,
+                                                                  const VROMatrix4f& resolvedTransform) {
     if (data.size() < 13 ||
         data[0] != kMeshSnapshotMagic[0] || data[1] != kMeshSnapshotMagic[1] ||
         data[2] != kMeshSnapshotMagic[2] || data[3] != kMeshSnapshotMagic[3] ||
@@ -589,7 +594,9 @@ std::shared_ptr<VROARDepthMesh> VROARWorldMesh::loadMeshSnapshot(const std::vect
         readFloat(data, offset, x);      offset += 4;
         readFloat(data, offset, y);      offset += 4;
         readFloat(data, offset, z);      offset += 4;
-        vertices.emplace_back(x, y, z);
+        // Stored relative to the original host's locationTransform; bring it
+        // into this session's world space via the resolved transform.
+        vertices.push_back(resolvedTransform.multiply(VROVector3f(x, y, z)));
     }
 
     std::vector<float> confidences;

--- a/ViroRenderer/VROARWorldMesh.cpp
+++ b/ViroRenderer/VROARWorldMesh.cpp
@@ -31,6 +31,15 @@
 #include "VROPencil.h"
 #include "VROLog.h"
 #include "VROPlatformUtil.h"
+#include "VROScene.h"
+#include "VROPortal.h"
+#include "VRONode.h"
+#include "VROGeometry.h"
+#include "VROGeometrySource.h"
+#include "VROGeometryElement.h"
+#include "VROMaterial.h"
+#include "VROShapeUtils.h"
+#include "VROData.h"
 #include <btBulletDynamicsCommon.h>
 #include <unordered_map>
 #include <algorithm>
@@ -617,4 +626,101 @@ std::shared_ptr<VROARDepthMesh> VROARWorldMesh::loadMeshSnapshot(const std::vect
 
     return std::make_shared<VROARDepthMesh>(std::move(vertices), std::move(indices),
                                              std::move(confidences), "snapshot");
+}
+
+// ─── WS-C: resolved (static) mesh attach — physics + visual occlusion ─────────
+
+void VROARWorldMesh::attachResolvedMesh(std::shared_ptr<VROARDepthMesh> mesh,
+                                         std::shared_ptr<VROScene> scene) {
+    if (!mesh || !mesh->isValid()) {
+        pwarn("VROARWorldMesh::attachResolvedMesh: invalid mesh, ignoring");
+        return;
+    }
+    // applyMeshToPhysics()'s async physics-body creation silently aborts if
+    // _enabled is false (see the render-thread callback above) — the world
+    // mesh feature must be turned on for a resolved mesh to take physical
+    // effect, same as the live mesh. Fail loudly here instead of a silent
+    // no-op three threads deep.
+    if (!_enabled) {
+        pwarn("VROARWorldMesh::attachResolvedMesh: world mesh is disabled "
+              "(call setEnabled(true) first) — ignoring resolved mesh");
+        return;
+    }
+
+    // Physics: identical pipeline to the live mesh (clustering/decimation +
+    // async BVH construction) — see applyMeshToPhysics() above.
+    applyMeshToPhysics(mesh);
+
+    // Visual occlusion: new static geometry, depth-only material.
+    if (scene) {
+        std::shared_ptr<VROGeometry> occlusionGeometry = buildOcclusionGeometry(mesh);
+        if (occlusionGeometry) {
+            std::shared_ptr<VRONode> node = std::make_shared<VRONode>();
+            node->setGeometry(occlusionGeometry);
+            scene->getRootNode()->addChildNode(node);
+        } else {
+            pwarn("VROARWorldMesh::attachResolvedMesh: failed to build occlusion geometry");
+        }
+    }
+}
+
+std::shared_ptr<VROGeometry> VROARWorldMesh::buildOcclusionGeometry(std::shared_ptr<VROARDepthMesh> mesh) {
+    if (!mesh || !mesh->isValid()) {
+        return nullptr;
+    }
+
+    const std::vector<VROVector3f>& vertices = mesh->getVertices();
+    const std::vector<int>&         indices  = mesh->getIndices();
+    if (vertices.empty() || indices.empty()) {
+        return nullptr;
+    }
+
+    // Depth-only occlusion material: writes depth, no color output — the
+    // mesh is never itself visible but still z-tests virtual content behind
+    // it. Unlit (Constant) since color never reaches the screen anyway.
+    std::shared_ptr<VROMaterial> material = std::make_shared<VROMaterial>();
+    material->setColorWriteMask(VROColorMaskNone);
+    material->setWritesToDepthBuffer(true);
+    material->setReadsFromDepthBuffer(true);
+    material->setCullMode(VROCullMode::None);
+    material->setLightingModel(VROLightingModel::Constant);
+
+    // Build interleaved position/uv/normal/tangent layout expected by
+    // VROShapeUtilBuildGeometrySources (same helper VROBox uses). UVs/tangents
+    // are unused by an occlusion-only material; normals are a placeholder
+    // direction — real per-vertex normals would require averaging adjacent
+    // face normals across the shared-index depth mesh, which buys nothing
+    // here since color output (and therefore lighting) never reaches the screen.
+    size_t numVertices = vertices.size();
+    std::vector<VROShapeVertexLayout> layout(numVertices);
+    for (size_t i = 0; i < numVertices; ++i) {
+        layout[i].x = vertices[i].x;
+        layout[i].y = vertices[i].y;
+        layout[i].z = vertices[i].z;
+        layout[i].u = 0.f;
+        layout[i].v = 0.f;
+        layout[i].nx = 0.f;
+        layout[i].ny = 1.f;
+        layout[i].nz = 0.f;
+        layout[i].tx = 1.f;
+        layout[i].ty = 0.f;
+        layout[i].tz = 0.f;
+        layout[i].tw = 1.f;
+    }
+
+    std::shared_ptr<VROData> vertexData = std::make_shared<VROData>(
+        (void *)layout.data(), (int)(sizeof(VROShapeVertexLayout) * numVertices));
+    std::vector<std::shared_ptr<VROGeometrySource>> sources =
+        VROShapeUtilBuildGeometrySources(vertexData, numVertices);
+
+    std::shared_ptr<VROData> indexData = std::make_shared<VROData>(
+        (void *)indices.data(), (int)(sizeof(int) * indices.size()));
+    std::shared_ptr<VROGeometryElement> element = std::make_shared<VROGeometryElement>(
+        indexData, VROGeometryPrimitiveType::Triangle,
+        (int)(indices.size() / 3), (int)sizeof(int));
+
+    std::shared_ptr<VROGeometry> geometry = std::make_shared<VROGeometry>(
+        sources, std::vector<std::shared_ptr<VROGeometryElement>>{element});
+    geometry->setMaterials({material});
+    return geometry;
 }

--- a/ViroRenderer/VROARWorldMesh.h
+++ b/ViroRenderer/VROARWorldMesh.h
@@ -34,6 +34,7 @@
 #include <mutex>
 #include <cstdint>
 #include "VROVector3f.h"
+#include "VROMatrix4f.h"
 
 class VROARDepthMesh;
 class VROARFrame;
@@ -241,26 +242,41 @@ public:
      * spec-invalid files (this repo has no way to open the result in a
      * glTF viewer to confirm correctness).
      *
+     * @param locationTransform The same anchor/location-frame transform used
+     *        to host this scan (RVCCACloudAnchorProvider's anchorTransform or
+     *        computeLocationTransform() result). Vertices are stored relative
+     *        to this frame (world = locationTransform * local), NOT in this
+     *        session's raw world space — a resolve on a different device has
+     *        a different, unrelated world origin, so raw world-space vertices
+     *        would be meaningless there. This mirrors how SIFT features are
+     *        already stored anchor/location-local (FeatureExtractor::toLocal).
+     *
      * Layout (little-endian, matches all current target architectures):
      *   [0:4)   magic "RVWM"
      *   [4:5)   format version (1)
      *   [5:9)   vertexCount   (uint32)
      *   [9:13)  triangleCount (uint32)
-     *   vertices:    vertexCount   * 3 * float32 (x,y,z, world space)
+     *   vertices:    vertexCount   * 3 * float32 (x,y,z, relative to locationTransform)
      *   confidences: vertexCount   * float32
      *   indices:     triangleCount * 3 * int32
      *
      * @return Empty vector if there is no current mesh.
      */
-    std::vector<uint8_t> serializeCurrentMesh() const;
+    std::vector<uint8_t> serializeCurrentMesh(const VROMatrix4f& locationTransform) const;
 
     /**
      * WS-C: reconstruct a VROARDepthMesh from bytes produced by
-     * serializeCurrentMesh() (e.g. downloaded from a resolved cloud anchor).
+     * serializeCurrentMesh(), transforming vertices from the stored
+     * location-frame-relative space into this session's world space.
      *
+     * @param resolvedTransform The transform resolveCloudAnchor() computed
+     *        for this session (the resolved anchor's world transform) —
+     *        the same role locationTransform played at host time, now
+     *        mapping local -> this session's world instead of the reverse.
      * @return nullptr if data is malformed (bad magic/version, truncated).
      */
-    static std::shared_ptr<VROARDepthMesh> loadMeshSnapshot(const std::vector<uint8_t>& data);
+    static std::shared_ptr<VROARDepthMesh> loadMeshSnapshot(const std::vector<uint8_t>& data,
+                                                             const VROMatrix4f& resolvedTransform);
 
 private:
     std::weak_ptr<VROPhysicsWorld> _physicsWorld;

--- a/ViroRenderer/VROARWorldMesh.h
+++ b/ViroRenderer/VROARWorldMesh.h
@@ -230,6 +230,38 @@ public:
      */
     void debugDraw(std::shared_ptr<VROPencil> pencil);
 
+    /**
+     * WS-C: serialize the current mesh (vertices, per-vertex confidences,
+     * triangle indices) into a compact custom binary format for persisting
+     * as a cloud anchor asset (see finishScan() and rvUploadAsset()).
+     *
+     * Not glTF: this format is only ever read back by loadMeshSnapshot() in
+     * this same class, not by third-party tools, so a minimal custom layout
+     * avoids the risk of an unvalidated hand-written glTF writer producing
+     * spec-invalid files (this repo has no way to open the result in a
+     * glTF viewer to confirm correctness).
+     *
+     * Layout (little-endian, matches all current target architectures):
+     *   [0:4)   magic "RVWM"
+     *   [4:5)   format version (1)
+     *   [5:9)   vertexCount   (uint32)
+     *   [9:13)  triangleCount (uint32)
+     *   vertices:    vertexCount   * 3 * float32 (x,y,z, world space)
+     *   confidences: vertexCount   * float32
+     *   indices:     triangleCount * 3 * int32
+     *
+     * @return Empty vector if there is no current mesh.
+     */
+    std::vector<uint8_t> serializeCurrentMesh() const;
+
+    /**
+     * WS-C: reconstruct a VROARDepthMesh from bytes produced by
+     * serializeCurrentMesh() (e.g. downloaded from a resolved cloud anchor).
+     *
+     * @return nullptr if data is malformed (bad magic/version, truncated).
+     */
+    static std::shared_ptr<VROARDepthMesh> loadMeshSnapshot(const std::vector<uint8_t>& data);
+
 private:
     std::weak_ptr<VROPhysicsWorld> _physicsWorld;
 

--- a/ViroRenderer/VROARWorldMesh.h
+++ b/ViroRenderer/VROARWorldMesh.h
@@ -41,6 +41,8 @@ class VROARFrame;
 class VROPhysicsWorld;
 class VROPhysicsShape;
 class VROPencil;
+class VROScene;
+class VROGeometry;
 class btRigidBody;
 class btDefaultMotionState;
 
@@ -277,6 +279,37 @@ public:
      */
     static std::shared_ptr<VROARDepthMesh> loadMeshSnapshot(const std::vector<uint8_t>& data,
                                                              const VROMatrix4f& resolvedTransform);
+
+    /**
+     * WS-C: attach a resolved (static) mesh snapshot loaded via
+     * loadMeshSnapshot() — the counterpart to the live per-frame mesh for
+     * mesh data recovered from a resolved cloud anchor's asset. Adds both:
+     *   - Physics: reuses applyMeshToPhysics() verbatim, the same pipeline
+     *     already used for the live mesh (clustering/decimation + async BVH).
+     *   - Visual occlusion: builds a static, invisible depth-only geometry
+     *     (see buildOcclusionGeometry()) and adds it to the scene root.
+     *     This path is NEW engine code, verified only by compilation — this
+     *     repo has no way to render an AR scene, so it has not been visually
+     *     confirmed to occlude correctly. Test on device before shipping.
+     *
+     * @param mesh The resolved mesh, already in this session's world space
+     *        (see loadMeshSnapshot()'s resolvedTransform parameter).
+     * @param scene The scene to add the occlusion geometry node to.
+     */
+    void attachResolvedMesh(std::shared_ptr<VROARDepthMesh> mesh, std::shared_ptr<VROScene> scene);
+
+    /**
+     * WS-C: build a static, invisible depth-only VROGeometry from a mesh's
+     * vertices/indices. The material writes to the depth buffer but not the
+     * color buffer (VROColorMaskNone) and disables culling (the mesh's
+     * winding was computed relative to a different session's camera, not
+     * guaranteed consistent for this session's viewpoints) — so it never
+     * appears itself but still correctly z-tests virtual content behind it.
+     * Public for testability; normally called via attachResolvedMesh().
+     *
+     * @return nullptr if mesh is null/invalid/empty.
+     */
+    static std::shared_ptr<VROGeometry> buildOcclusionGeometry(std::shared_ptr<VROARDepthMesh> mesh);
 
 private:
     std::weak_ptr<VROPhysicsWorld> _physicsWorld;

--- a/ViroRenderer/VROGeospatial.h
+++ b/ViroRenderer/VROGeospatial.h
@@ -35,8 +35,16 @@
 enum class VROEarthTrackingState {
     Tracking,   // Earth is being tracked with VPS/GPS fusion
     Paused,     // Tracking is paused (e.g., app backgrounded)
-    Stopped     // No tracking available
+    Stopped,    // No tracking available
+    // WS-D: appended, not inserted — Android's JNI bridge maps this enum to Java
+    // by raw ordinal (ARScene.java), so existing positions must not shift.
+    Localizing  // GPS fix acquired but not yet within the accuracy threshold
 };
+
+// WS-D: horizontal accuracy (meters) below which a GPS-only geospatial pose is
+// considered localized rather than still converging. Placeholder default —
+// will become app-configurable via the JS bridge (WS-D follow-up task).
+constexpr double kVROGeospatialAccuracyThresholdMeters = 15.0;
 
 /*
  * Represents the availability of Visual Positioning System (VPS) at a location.
@@ -159,6 +167,7 @@ inline std::string VROEarthTrackingStateToString(VROEarthTrackingState state) {
         case VROEarthTrackingState::Tracking: return "TRACKING";
         case VROEarthTrackingState::Paused: return "PAUSED";
         case VROEarthTrackingState::Stopped: return "STOPPED";
+        case VROEarthTrackingState::Localizing: return "LOCALIZING";
     }
     return "UNKNOWN";
 }

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -24,6 +24,7 @@
 //  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #include <jni/ARImageDatabaseLoaderDelegate.h>
+#include <cstdlib>
 #include "ARSceneController_JNI.h"
 #include "ARDeclarativePlane_JNI.h"
 #include "ARDeclarativeNode_JNI.h"
@@ -681,6 +682,31 @@ static void rvFireCloudResult(VRO_WEAK weakObj, std::string keyStr,
     });
 }
 
+// WS-C: separate from rvFireCloudResult() because finishScan() also carries
+// the location transform (ARScene.RvFinishScanCallback, 4 args vs 3).
+static void rvFireFinishScanResult(VRO_WEAK weakObj, std::string keyStr,
+                                    bool success, std::string cloudAnchorId,
+                                    std::string locationTransformCsv, std::string error) {
+    VROPlatformDispatchAsyncApplication([weakObj, keyStr, success, cloudAnchorId, locationTransformCsv, error] {
+        VRO_ENV env = VROPlatformGetJNIEnv();
+        VRO_OBJECT localObj = VRO_NEW_LOCAL_REF(weakObj);
+        if (VRO_IS_OBJECT_NULL(localObj)) {
+            VRO_DELETE_LOCAL_REF(localObj);
+            VRO_DELETE_WEAK_GLOBAL_REF(weakObj);
+            return;
+        }
+        VRO_STRING jKey  = VRO_NEW_STRING(keyStr.c_str());
+        VRO_STRING jId   = VRO_NEW_STRING(cloudAnchorId.c_str());
+        VRO_STRING jCsv  = VRO_NEW_STRING(locationTransformCsv.c_str());
+        VRO_STRING jErr  = VRO_NEW_STRING(error.c_str());
+        VROPlatformCallHostFunction(localObj, "onRvFinishScanResult",
+            "(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+            jKey, (jboolean)success, jId, jCsv, jErr);
+        VRO_DELETE_LOCAL_REF(localObj);
+        VRO_DELETE_WEAK_GLOBAL_REF(weakObj);
+    });
+}
+
 VRO_METHOD(void, nativeRvStartScan)(VRO_ARGS
                                     VRO_REF(VROARSceneController) arSceneControllerPtr) {
     std::weak_ptr<VROARScene> arScene_w = std::dynamic_pointer_cast<VROARScene>(
@@ -705,12 +731,13 @@ VRO_METHOD(void, nativeRvFinishScan)(VRO_ARGS
         std::shared_ptr<VROARScene> arScene = arScene_w.lock();
         std::shared_ptr<VROARSession> arSession = arScene ? arScene->getARSession() : nullptr;
         if (!arSession) {
-            rvFireCloudResult(weakObj, keyStr, false, "", "AR session not available");
+            rvFireFinishScanResult(weakObj, keyStr, false, "", "", "AR session not available");
             return;
         }
         arSession->rvFinishScan((int)ttlDays,
-            [weakObj, keyStr](bool success, std::string cloudAnchorId, std::string error) {
-                rvFireCloudResult(weakObj, keyStr, success, cloudAnchorId, error);
+            [weakObj, keyStr](bool success, std::string cloudAnchorId,
+                              std::string locationTransformCsv, std::string error) {
+                rvFireFinishScanResult(weakObj, keyStr, success, cloudAnchorId, locationTransformCsv, error);
             });
     });
 }
@@ -1718,11 +1745,35 @@ VRO_METHOD(void, nativeSetWorldMeshConfig)(VRO_ARGS
     });
 }
 
+// WS-C: parses the CSV produced by rvMatrixToCsvARC() (this file) back into
+// a VROMatrix4f. Returns identity if malformed (16 values expected).
+static VROMatrix4f rvParseMatrixCsvARC(const std::string& csv) {
+    float values[16];
+    size_t start = 0;
+    int i = 0;
+    while (i < 16) {
+        size_t comma = csv.find(',', start);
+        std::string token = (comma == std::string::npos)
+            ? csv.substr(start) : csv.substr(start, comma - start);
+        values[i] = strtof(token.c_str(), nullptr);
+        i++;
+        if (comma == std::string::npos) break;
+        start = comma + 1;
+    }
+    if (i != 16) {
+        return VROMatrix4f();
+    }
+    return VROMatrix4f(values);
+}
+
 // WS-C: synchronous — returns the serialized current mesh, or null if there
 // is no mesh yet. Java writes the bytes to a cache file (see
-// ARScene.rvSnapshotWorldMeshToFile()).
+// ARScene.rvSnapshotWorldMeshToFile()). locationTransformCsv is the value
+// finishScan() returned — there is no placed anchor to read a transform
+// from otherwise.
 VRO_METHOD(jbyteArray, nativeRvSnapshotWorldMesh)(VRO_ARGS
-                                                  VRO_REF(VROARSceneController) sceneController_j) {
+                                                  VRO_REF(VROARSceneController) sceneController_j,
+                                                  jstring locationTransformCsv_j) {
     std::shared_ptr<VROARScene> scene = std::dynamic_pointer_cast<VROARScene>(
             VRO_REF_GET(VROARSceneController, sceneController_j)->getScene());
     if (!scene) {
@@ -1734,7 +1785,10 @@ VRO_METHOD(jbyteArray, nativeRvSnapshotWorldMesh)(VRO_ARGS
         return nullptr;
     }
 
-    std::vector<uint8_t> bytes = worldMesh->serializeCurrentMesh();
+    std::string csv = VRO_STRING_STL(locationTransformCsv_j);
+    VROMatrix4f locationTransform = rvParseMatrixCsvARC(csv);
+
+    std::vector<uint8_t> bytes = worldMesh->serializeCurrentMesh(locationTransform);
     if (bytes.empty()) {
         return nullptr;
     }

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -1497,6 +1497,19 @@ VRO_METHOD(void, nativeHostCloudAnchor)(VRO_ARGS
     });
 }
 
+// WS-C: mirrors rvMatrixToCsvARC() (VROARSessionARCore.cpp) so a resolved
+// anchor's transform can be threaded into loadWorldMeshFromFile().
+static std::string rvMatrixToCsvJNI(const VROMatrix4f& m) {
+    const float* a = m.getArray();
+    std::string csv;
+    char buf[32];
+    for (int i = 0; i < 16; ++i) {
+        snprintf(buf, sizeof(buf), i == 0 ? "%g" : ",%g", a[i]);
+        csv += buf;
+    }
+    return csv;
+}
+
 VRO_METHOD(void, nativeResolveCloudAnchor)(VRO_ARGS
                                            VRO_REF(VROARSceneController) sceneController_j,
                                            VRO_STRING cloudAnchorId_j) {
@@ -1543,9 +1556,12 @@ VRO_METHOD(void, nativeResolveCloudAnchor)(VRO_ARGS
                        nodeId = cloudAnchor->getARNode()->getUniqueID();
                    }
 
+                   // WS-C: lets the caller thread this straight into loadWorldMeshFromFile().
+                   VRO_STRING resolvedTransform_j = VRO_NEW_STRING(rvMatrixToCsvJNI(cloudAnchor->getTransform()).c_str());
+
                    VROPlatformCallHostFunction(obj_j, "onResolveSuccess",
-                                               "(Ljava/lang/String;Lcom/viro/core/ARAnchor;I)V",
-                                               cloudAnchorId_j, anchor_j, nodeId);
+                                               "(Ljava/lang/String;Lcom/viro/core/ARAnchor;ILjava/lang/String;)V",
+                                               cloudAnchorId_j, anchor_j, nodeId, resolvedTransform_j);
 
                    VRO_DELETE_LOCAL_REF(obj_j);
                    VRO_DELETE_WEAK_GLOBAL_REF(obj_w);

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -681,6 +681,40 @@ static void rvFireCloudResult(VRO_WEAK weakObj, std::string keyStr,
     });
 }
 
+VRO_METHOD(void, nativeRvStartScan)(VRO_ARGS
+                                    VRO_REF(VROARSceneController) arSceneControllerPtr) {
+    std::weak_ptr<VROARScene> arScene_w = std::dynamic_pointer_cast<VROARScene>(
+        VRO_REF_GET(VROARSceneController, arSceneControllerPtr)->getScene());
+    VROPlatformDispatchAsyncRenderer([arScene_w] {
+        std::shared_ptr<VROARScene> arScene = arScene_w.lock();
+        std::shared_ptr<VROARSession> arSession = arScene ? arScene->getARSession() : nullptr;
+        if (arSession) {
+            arSession->rvStartScan();
+        }
+    });
+}
+
+VRO_METHOD(void, nativeRvFinishScan)(VRO_ARGS
+                                     VRO_REF(VROARSceneController) arSceneControllerPtr,
+                                     jstring key_j, jint ttlDays) {
+    std::string keyStr = VRO_STRING_STL(key_j);
+    std::weak_ptr<VROARScene> arScene_w = std::dynamic_pointer_cast<VROARScene>(
+        VRO_REF_GET(VROARSceneController, arSceneControllerPtr)->getScene());
+    VRO_WEAK weakObj = VRO_NEW_WEAK_GLOBAL_REF(obj);
+    VROPlatformDispatchAsyncRenderer([arScene_w, weakObj, keyStr, ttlDays] {
+        std::shared_ptr<VROARScene> arScene = arScene_w.lock();
+        std::shared_ptr<VROARSession> arSession = arScene ? arScene->getARSession() : nullptr;
+        if (!arSession) {
+            rvFireCloudResult(weakObj, keyStr, false, "", "AR session not available");
+            return;
+        }
+        arSession->rvFinishScan((int)ttlDays,
+            [weakObj, keyStr](bool success, std::string cloudAnchorId, std::string error) {
+                rvFireCloudResult(weakObj, keyStr, success, cloudAnchorId, error);
+            });
+    });
+}
+
 VRO_METHOD(void, nativeRvGetCloudAnchor)(VRO_ARGS
                                          VRO_REF(VROARSceneController) arSceneControllerPtr,
                                          jstring key_j, jstring anchorId_j) {

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -1718,6 +1718,33 @@ VRO_METHOD(void, nativeSetWorldMeshConfig)(VRO_ARGS
     });
 }
 
+// WS-C: synchronous — returns the serialized current mesh, or null if there
+// is no mesh yet. Java writes the bytes to a cache file (see
+// ARScene.rvSnapshotWorldMeshToFile()).
+VRO_METHOD(jbyteArray, nativeRvSnapshotWorldMesh)(VRO_ARGS
+                                                  VRO_REF(VROARSceneController) sceneController_j) {
+    std::shared_ptr<VROARScene> scene = std::dynamic_pointer_cast<VROARScene>(
+            VRO_REF_GET(VROARSceneController, sceneController_j)->getScene());
+    if (!scene) {
+        return nullptr;
+    }
+
+    std::shared_ptr<VROARWorldMesh> worldMesh = scene->getWorldMesh();
+    if (!worldMesh) {
+        return nullptr;
+    }
+
+    std::vector<uint8_t> bytes = worldMesh->serializeCurrentMesh();
+    if (bytes.empty()) {
+        return nullptr;
+    }
+
+    jbyteArray result = env->NewByteArray((jsize)bytes.size());
+    env->SetByteArrayRegion(result, 0, (jsize)bytes.size(),
+                             reinterpret_cast<const jbyte*>(bytes.data()));
+    return result;
+}
+
 // +---------------------------------------------------------------------------+
 // | Scene Semantics API
 // +---------------------------------------------------------------------------+

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -1799,6 +1799,42 @@ VRO_METHOD(jbyteArray, nativeRvSnapshotWorldMesh)(VRO_ARGS
     return result;
 }
 
+// WS-C: reverse of nativeRvSnapshotWorldMesh — load a resolved mesh snapshot
+// and attach it for physics + visual occlusion. See VROARWorldMesh::
+// attachResolvedMesh() for the (compile-verified only, not visually tested)
+// occlusion geometry construction. Returns false if there's no scene, no
+// world mesh (setWorldMeshEnabled(true) not called), or malformed bytes.
+VRO_METHOD(jboolean, nativeRvLoadWorldMesh)(VRO_ARGS
+                                            VRO_REF(VROARSceneController) sceneController_j,
+                                            jbyteArray meshBytes_j,
+                                            jstring resolvedTransformCsv_j) {
+    std::shared_ptr<VROARScene> scene = std::dynamic_pointer_cast<VROARScene>(
+            VRO_REF_GET(VROARSceneController, sceneController_j)->getScene());
+    if (!scene) {
+        return JNI_FALSE;
+    }
+
+    std::shared_ptr<VROARWorldMesh> worldMesh = scene->getWorldMesh();
+    if (!worldMesh) {
+        return JNI_FALSE;
+    }
+
+    jsize len = env->GetArrayLength(meshBytes_j);
+    std::vector<uint8_t> bytes((size_t)len);
+    env->GetByteArrayRegion(meshBytes_j, 0, len, reinterpret_cast<jbyte*>(bytes.data()));
+
+    std::string csv = VRO_STRING_STL(resolvedTransformCsv_j);
+    VROMatrix4f resolvedTransform = rvParseMatrixCsvARC(csv);
+
+    std::shared_ptr<VROARDepthMesh> mesh = VROARWorldMesh::loadMeshSnapshot(bytes, resolvedTransform);
+    if (!mesh) {
+        return JNI_FALSE;
+    }
+
+    worldMesh->attachResolvedMesh(mesh, scene);
+    return JNI_TRUE;
+}
+
 // +---------------------------------------------------------------------------+
 // | Scene Semantics API
 // +---------------------------------------------------------------------------+

--- a/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
@@ -1659,8 +1659,16 @@ void VROARSessionARCore::setGeospatialAnchorProvider(VROGeospatialAnchorProvider
 VROEarthTrackingState VROARSessionARCore::getEarthTrackingState() const {
 #if RVCCA_AVAILABLE
     if (getGeospatialAnchorProvider() == VROGeospatialAnchorProvider::ReactVision) {
-        return _geospatialProviderRV ? VROEarthTrackingState::Tracking
-                                     : VROEarthTrackingState::Stopped;
+        if (!_geospatialProviderRV) {
+            return VROEarthTrackingState::Stopped;
+        }
+        // WS-D: mirrors the iOS fix — Tracking requires a GPS fix within the
+        // accuracy threshold, not just the provider existing.
+        bool accurate = _lastKnownGPSPose.isValid() &&
+                        _lastKnownGPSPose.horizontalAccuracy > 0 &&
+                        _lastKnownGPSPose.horizontalAccuracy < kVROGeospatialAccuracyThresholdMeters;
+        return accurate ? VROEarthTrackingState::Tracking
+                        : VROEarthTrackingState::Localizing;
     }
 #endif
     if (!_session) return VROEarthTrackingState::Stopped;
@@ -2448,6 +2456,38 @@ static std::string rvCloudAnchorToJsonARC(const ReactVisionCCA::CloudAnchorRecor
     return j;
 }
 #endif // RVCCA_AVAILABLE
+
+void VROARSessionARCore::rvStartScan() {
+#if RVCCA_AVAILABLE
+    if (_cloudAnchorProviderRV) {
+        auto p = _cloudAnchorProviderRV->getProvider();
+        if (p) {
+            p->startScan();
+        }
+    }
+#endif
+}
+
+void VROARSessionARCore::rvFinishScan(
+    int ttlDays,
+    std::function<void(bool, std::string, std::string)> callback) {
+#if RVCCA_AVAILABLE
+    if (_cloudAnchorProviderRV) {
+        auto p = _cloudAnchorProviderRV->getProvider();
+        if (p) {
+            p->finishScan(ttlDays,
+                [callback](const std::string& cloudAnchorId) {
+                    if (callback) callback(true, cloudAnchorId, "");
+                },
+                [callback](const std::string& error, ReactVisionCCA::RVCCACloudAnchorProvider::ErrorCode) {
+                    if (callback) callback(false, "", error);
+                });
+            return;
+        }
+    }
+#endif
+    if (callback) callback(false, "", "ReactVision cloud anchor provider not available");
+}
 
 void VROARSessionARCore::rvGetCloudAnchor(
     const std::string& anchorId,

--- a/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.cpp
@@ -2414,6 +2414,20 @@ static std::string rvCloudAssetToJsonARC(const ReactVisionCCA::CloudAnchorAsset&
     return j;
 }
 
+// WS-C: mirrors rvMatrixToCsv() in VROARSessioniOS.cpp — 16 comma-separated
+// floats (column-major, matching getArray()) so the transform can cross the
+// RN bridge as an opaque string. See VROARSession::rvFinishScan().
+static std::string rvMatrixToCsvARC(const VROMatrix4f& m) {
+    const float* a = m.getArray();
+    std::string csv;
+    char buf[32];
+    for (int i = 0; i < 16; ++i) {
+        snprintf(buf, sizeof(buf), i == 0 ? "%g" : ",%g", a[i]);
+        csv += buf;
+    }
+    return csv;
+}
+
 static std::string rvCloudAnchorToJsonARC(const ReactVisionCCA::CloudAnchorRecord& r) {
     char buf[128];
     std::string j = "{";
@@ -2470,23 +2484,23 @@ void VROARSessionARCore::rvStartScan() {
 
 void VROARSessionARCore::rvFinishScan(
     int ttlDays,
-    std::function<void(bool, std::string, std::string)> callback) {
+    std::function<void(bool, std::string, std::string, std::string)> callback) {
 #if RVCCA_AVAILABLE
     if (_cloudAnchorProviderRV) {
         auto p = _cloudAnchorProviderRV->getProvider();
         if (p) {
             p->finishScan(ttlDays,
-                [callback](const std::string& cloudAnchorId) {
-                    if (callback) callback(true, cloudAnchorId, "");
+                [callback](const std::string& cloudAnchorId, const VROMatrix4f& locationTransform) {
+                    if (callback) callback(true, cloudAnchorId, rvMatrixToCsvARC(locationTransform), "");
                 },
                 [callback](const std::string& error, ReactVisionCCA::RVCCACloudAnchorProvider::ErrorCode) {
-                    if (callback) callback(false, "", error);
+                    if (callback) callback(false, "", "", error);
                 });
             return;
         }
     }
 #endif
-    if (callback) callback(false, "", "ReactVision cloud anchor provider not available");
+    if (callback) callback(false, "", "", "ReactVision cloud anchor provider not available");
 }
 
 void VROARSessionARCore::rvGetCloudAnchor(

--- a/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.h
+++ b/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.h
@@ -217,7 +217,7 @@ public:
     // Cloud anchor management
     void rvStartScan() override;
     void rvFinishScan(int ttlDays,
-        std::function<void(bool, std::string, std::string)> callback) override;
+        std::function<void(bool, std::string, std::string, std::string)> callback) override;
     void rvGetCloudAnchor(const std::string& anchorId,
         std::function<void(bool, std::string, std::string)> callback) override;
     void rvListCloudAnchors(int limit, int offset,

--- a/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.h
+++ b/android/sharedCode/src/main/cpp/arcore/VROARSessionARCore.h
@@ -215,6 +215,9 @@ public:
         std::function<void(bool, std::string, std::string)> callback) override;
 
     // Cloud anchor management
+    void rvStartScan() override;
+    void rvFinishScan(int ttlDays,
+        std::function<void(bool, std::string, std::string)> callback) override;
     void rvGetCloudAnchor(const std::string& anchorId,
         std::function<void(bool, std::string, std::string)> callback) override;
     void rvListCloudAnchors(int limit, int offset,

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -1627,6 +1627,17 @@ public class ARScene extends Scene {
     }
 
     /**
+     * WS-C: serialize the current world mesh (vertices, confidences, triangle
+     * indices) into a compact binary format for persisting as a cloud anchor
+     * asset. Returns null if there is no current mesh.
+     *
+     * @return the serialized bytes, or null.
+     */
+    public byte[] rvSnapshotWorldMesh() {
+        return nativeRvSnapshotWorldMesh(mNativeRef);
+    }
+
+    /**
      * Configure the world mesh generation and physics properties.
      *
      * @param stride Sample every Nth pixel from depth image (lower = more detail)
@@ -1777,6 +1788,7 @@ public class ARScene extends Scene {
 
     // World Mesh API native methods
     private native void nativeSetWorldMeshEnabled(long sceneControllerRef, boolean enabled);
+    private native byte[] nativeRvSnapshotWorldMesh(long sceneControllerRef);
     private native void nativeSetWorldMeshConfig(long sceneControllerRef,
                                                   int stride,
                                                   float minConfidence,

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -1361,6 +1361,24 @@ public class ARScene extends Scene {
     }
 
     /**
+     * WS-C: callback for {@link #rvFinishScan} — separate from
+     * {@link RvCloudAnchorCallback} because it also carries the location
+     * transform (needed for {@link #rvSnapshotWorldMesh}, since a
+     * finishScan()-hosted anchor has no placed anchor to read a transform from).
+     */
+    public interface RvFinishScanCallback {
+        void onResult(boolean success, String cloudAnchorId, String locationTransformCsv, String error);
+    }
+
+    private Map<String, RvFinishScanCallback> mRvFinishScanCallbacks = new HashMap<>();
+
+    void onRvFinishScanResult(String key, boolean success, String cloudAnchorId,
+                               String locationTransformCsv, String error) {
+        RvFinishScanCallback cb = mRvFinishScanCallbacks.remove(key);
+        if (cb != null) cb.onResult(success, cloudAnchorId, locationTransformCsv, error);
+    }
+
+    /**
      * WS-A: begin a room/building-scale scan with its own self-defined location
      * frame, independent of any placed anchor. Resets the native background
      * keyframe buffer. Call {@link #rvFinishScan} when done scanning.
@@ -1374,9 +1392,9 @@ public class ARScene extends Scene {
      * cloud. Same pipeline as a placed-anchor host, but positions content in
      * the scan's own location frame instead of relative to an anchor.
      */
-    public void rvFinishScan(int ttlDays, RvCloudAnchorCallback callback) {
+    public void rvFinishScan(int ttlDays, RvFinishScanCallback callback) {
         String key = "rvFinishScan_" + System.nanoTime();
-        mRvCloudCallbacks.put(key, callback);
+        mRvFinishScanCallbacks.put(key, callback);
         nativeRvFinishScan(mNativeRef, key, ttlDays);
     }
 
@@ -1631,10 +1649,12 @@ public class ARScene extends Scene {
      * indices) into a compact binary format for persisting as a cloud anchor
      * asset. Returns null if there is no current mesh.
      *
+     * @param locationTransformCsv the value {@link RvFinishScanCallback} returned —
+     *        there is no placed anchor to read a transform from otherwise.
      * @return the serialized bytes, or null.
      */
-    public byte[] rvSnapshotWorldMesh() {
-        return nativeRvSnapshotWorldMesh(mNativeRef);
+    public byte[] rvSnapshotWorldMesh(String locationTransformCsv) {
+        return nativeRvSnapshotWorldMesh(mNativeRef, locationTransformCsv);
     }
 
     /**
@@ -1788,7 +1808,7 @@ public class ARScene extends Scene {
 
     // World Mesh API native methods
     private native void nativeSetWorldMeshEnabled(long sceneControllerRef, boolean enabled);
-    private native byte[] nativeRvSnapshotWorldMesh(long sceneControllerRef);
+    private native byte[] nativeRvSnapshotWorldMesh(long sceneControllerRef, String locationTransformCsv);
     private native void nativeSetWorldMeshConfig(long sceneControllerRef,
                                                   int stride,
                                                   float minConfidence,

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -183,8 +183,11 @@ public class ARScene extends Scene {
          * @param anchor The new, successfully resolved, cloud anchor.
          * @param arNode The ARNode attached and synchronized to the cloud anchor, to which you
          *               can add virtual content.
+         * @param resolvedTransform Opaque CSV-encoded transform for this resolved anchor (WS-C).
+         *               Thread it into {@code loadWorldMeshFromFile} to attach a mesh snapshot
+         *               hosted alongside this anchor. Treat as opaque; do not parse.
          */
-        public void onSuccess(ARAnchor anchor, ARNode arNode);
+        public void onSuccess(ARAnchor anchor, ARNode arNode, String resolvedTransform);
 
         /**
          * Invoked when the system fails to resolve an anchor. Anchor resolution can fail for a
@@ -1040,7 +1043,7 @@ public class ARScene extends Scene {
     }
 
     // Called by native
-    void onResolveSuccess(String cloudAnchorId, ARAnchor cloudAnchor, int arNodeId) {
+    void onResolveSuccess(String cloudAnchorId, ARAnchor cloudAnchor, int arNodeId, String resolvedTransform) {
         if (!cloudAnchorId.equals(cloudAnchor.getCloudAnchorId())) {
             throw new IllegalStateException("Resolved cloud anchor ID [" + cloudAnchor.getCloudAnchorId() +
                     "] does not match requested ID [" + cloudAnchorId + "]!");
@@ -1056,7 +1059,7 @@ public class ARScene extends Scene {
                     node = new ARNode(arNodeId);
                 }
             }
-            callback.onSuccess(cloudAnchor, node);
+            callback.onSuccess(cloudAnchor, node, resolvedTransform);
         } else {
             Log.e("Viro", "Cloud anchor resolve successful, but no callback found to invoke [anchor ID: "
                     + cloudAnchorId + "]");

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -215,7 +215,13 @@ public class ARScene extends Scene {
         /**
          * Geospatial tracking is stopped or not initialized.
          */
-        STOPPED
+        STOPPED,
+        /**
+         * WS-D: GPS fix acquired but not yet within the accuracy threshold —
+         * appended last to keep the native ordinal mapping in
+         * {@link #getEarthTrackingState()} stable for ENABLED/PAUSED/STOPPED.
+         */
+        LOCALIZING
     }
 
     /**
@@ -1114,6 +1120,9 @@ public class ARScene extends Scene {
             case 1:
                 return EarthTrackingState.PAUSED;
             case 2:
+                return EarthTrackingState.STOPPED;
+            case 3:
+                return EarthTrackingState.LOCALIZING;
             default:
                 return EarthTrackingState.STOPPED;
         }
@@ -1349,6 +1358,26 @@ public class ARScene extends Scene {
     void onRvCloudAnchorResult(String key, boolean success, String jsonData, String error) {
         RvCloudAnchorCallback cb = mRvCloudCallbacks.remove(key);
         if (cb != null) cb.onResult(success, jsonData, error);
+    }
+
+    /**
+     * WS-A: begin a room/building-scale scan with its own self-defined location
+     * frame, independent of any placed anchor. Resets the native background
+     * keyframe buffer. Call {@link #rvFinishScan} when done scanning.
+     */
+    public void rvStartScan() {
+        nativeRvStartScan(mNativeRef);
+    }
+
+    /**
+     * WS-A: finish a scan started with {@link #rvStartScan} and host it to the
+     * cloud. Same pipeline as a placed-anchor host, but positions content in
+     * the scan's own location frame instead of relative to an anchor.
+     */
+    public void rvFinishScan(int ttlDays, RvCloudAnchorCallback callback) {
+        String key = "rvFinishScan_" + System.nanoTime();
+        mRvCloudCallbacks.put(key, callback);
+        nativeRvFinishScan(mNativeRef, key, ttlDays);
     }
 
     public void rvGetCloudAnchor(String anchorId, RvCloudAnchorCallback callback) {
@@ -1714,6 +1743,8 @@ public class ARScene extends Scene {
                                                        int limit, int offset);
 
     // Cloud anchor management native methods
+    private native void nativeRvStartScan(long sceneControllerRef);
+    private native void nativeRvFinishScan(long sceneControllerRef, String key, int ttlDays);
     private native void nativeRvGetCloudAnchor(long sceneControllerRef, String key, String anchorId);
     private native void nativeRvListCloudAnchors(long sceneControllerRef, String key,
                                                   int limit, int offset);

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -1658,6 +1658,20 @@ public class ARScene extends Scene {
     }
 
     /**
+     * WS-C: reverse of {@link #rvSnapshotWorldMesh} — load a resolved mesh
+     * snapshot and attach it for both physics collision and visual occlusion.
+     * Requires {@link #setWorldMeshEnabled} to have been called with true.
+     *
+     * @param meshBytes bytes downloaded from the resolved anchor's mesh asset.
+     * @param resolvedTransformCsv the resolved anchor's transform (16
+     *        comma-separated floats).
+     * @return false if there is no world mesh or the bytes are malformed.
+     */
+    public boolean rvLoadWorldMesh(byte[] meshBytes, String resolvedTransformCsv) {
+        return nativeRvLoadWorldMesh(mNativeRef, meshBytes, resolvedTransformCsv);
+    }
+
+    /**
      * Configure the world mesh generation and physics properties.
      *
      * @param stride Sample every Nth pixel from depth image (lower = more detail)
@@ -1809,6 +1823,7 @@ public class ARScene extends Scene {
     // World Mesh API native methods
     private native void nativeSetWorldMeshEnabled(long sceneControllerRef, boolean enabled);
     private native byte[] nativeRvSnapshotWorldMesh(long sceneControllerRef, String locationTransformCsv);
+    private native boolean nativeRvLoadWorldMesh(long sceneControllerRef, byte[] meshBytes, String resolvedTransformCsv);
     private native void nativeSetWorldMeshConfig(long sceneControllerRef,
                                                   int stride,
                                                   float minConfidence,

--- a/ios/ViroKit/VROARSessioniOS.cpp
+++ b/ios/ViroKit/VROARSessioniOS.cpp
@@ -2432,6 +2432,20 @@ static std::string rvCloudAssetToJson(const ReactVisionCCA::CloudAnchorAsset& a)
     return j;
 }
 
+// WS-C: serializes a VROMatrix4f as 16 comma-separated floats (column-major,
+// matching getArray()) so it can cross the RN bridge as an opaque string —
+// see VROARSession::rvFinishScan().
+static std::string rvMatrixToCsv(const VROMatrix4f& m) {
+    const float* a = m.getArray();
+    std::string csv;
+    char buf[32];
+    for (int i = 0; i < 16; ++i) {
+        snprintf(buf, sizeof(buf), i == 0 ? "%g" : ",%g", a[i]);
+        csv += buf;
+    }
+    return csv;
+}
+
 static std::string rvCloudAnchorToJson(const ReactVisionCCA::CloudAnchorRecord& r) {
     char buf[128];
     std::string j = "{";
@@ -2489,21 +2503,21 @@ void VROARSessioniOS::rvStartScan() {
 
 void VROARSessioniOS::rvFinishScan(
     int ttlDays,
-    std::function<void(bool, std::string, std::string)> callback) {
+    std::function<void(bool, std::string, std::string, std::string)> callback) {
 #if RVCCA_AVAILABLE
   auto p = [_cloudAnchorProviderRV cppProvider];
   if (p) {
     p->finishScan(ttlDays,
-        [callback](const std::string& cloudAnchorId) {
-          if (callback) callback(true, cloudAnchorId, "");
+        [callback](const std::string& cloudAnchorId, const VROMatrix4f& locationTransform) {
+          if (callback) callback(true, cloudAnchorId, rvMatrixToCsv(locationTransform), "");
         },
         [callback](const std::string& error, ReactVisionCCA::RVCCACloudAnchorProvider::ErrorCode) {
-          if (callback) callback(false, "", error);
+          if (callback) callback(false, "", "", error);
         });
     return;
   }
 #endif
-  if (callback) callback(false, "", "ReactVision cloud anchor provider not available");
+  if (callback) callback(false, "", "", "ReactVision cloud anchor provider not available");
 }
 
 void VROARSessioniOS::rvGetCloudAnchor(

--- a/ios/ViroKit/VROARSessioniOS.cpp
+++ b/ios/ViroKit/VROARSessioniOS.cpp
@@ -65,6 +65,10 @@
 @property (nonatomic, strong) CLLocationManager *locationManager;
 // Raw pointer into the owning VROARSessioniOS; cleared before the session dies.
 @property (nonatomic, assign) VROGeospatialPose *poseOut;
+// WS-D: true once we've confirmed the OS will only give approximate location
+// (iOS 14+ "Precise Location" off) and a temporary full-accuracy request was
+// denied, is pending, or unavailable pre-iOS 14. See start's accuracyAuthorization check.
+@property (nonatomic, assign) BOOL reducedAccuracy;
 @end
 
 @implementation VROLocationDelegate
@@ -90,6 +94,37 @@
     if (status == kCLAuthorizationStatusNotDetermined) {
         [_locationManager requestWhenInUseAuthorization];
     }
+
+    // WS-D: iOS 14+ users can grant only approximate location ("Precise Location"
+    // off). horizontalAccuracy then stays at the ~km scale and never crosses
+    // kVROGeospatialAccuracyThresholdMeters, so getEarthTrackingState() would sit
+    // in Localizing forever with no signal to the app. Request a temporary precise
+    // fix and surface the outcome via reducedAccuracy so the app can show an
+    // explicit error instead of a silent hang.
+    // Requires an NSLocationTemporaryUsageDescriptionDictionary entry for the key
+    // below in the consuming app's Info.plist — without it this call is a no-op
+    // and reducedAccuracy stays true.
+    if (@available(iOS 14.0, *)) {
+        if (_locationManager.accuracyAuthorization == CLAccuracyAuthorizationReducedAccuracy) {
+            _reducedAccuracy = YES;
+            __weak VROLocationDelegate *weakSelf = self;
+            [_locationManager requestTemporaryFullAccuracyAuthorizationWithPurposeKey:@"ReactVisionVPSAccuracy"
+                completion:^(NSError * _Nullable error) {
+                __strong VROLocationDelegate *strongSelf = weakSelf;
+                if (!strongSelf) return;
+                strongSelf.reducedAccuracy =
+                    (strongSelf.locationManager.accuracyAuthorization == CLAccuracyAuthorizationReducedAccuracy);
+                if (strongSelf.reducedAccuracy) {
+                    pwarn("ReactVision: location accuracy is reduced — geospatial "
+                          "tracking will never converge. Add an "
+                          "NSLocationTemporaryUsageDescriptionDictionary entry for key "
+                          "'ReactVisionVPSAccuracy' in Info.plist to allow requesting "
+                          "temporary full accuracy.");
+                }
+            }];
+        }
+    }
+
     [_locationManager startUpdatingLocation];
     [_locationManager startUpdatingHeading];
 }
@@ -1757,8 +1792,17 @@ void VROARSessioniOS::setGeospatialModeEnabled(bool enabled) {
 VROEarthTrackingState VROARSessioniOS::getEarthTrackingState() const {
 #if RVCCA_AVAILABLE
   if (getGeospatialAnchorProvider() == VROGeospatialAnchorProvider::ReactVision) {
-    return _geospatialProviderRV ? VROEarthTrackingState::Enabled
-                                 : VROEarthTrackingState::Stopped;
+    if (!_geospatialProviderRV) {
+      return VROEarthTrackingState::Stopped;
+    }
+    // WS-D: Enabled requires an actual GPS fix within the accuracy threshold —
+    // previously this returned Enabled the instant the provider existed, even
+    // with a stale/zero pose, hiding the ~1 min cold-start wait from the app.
+    bool accurate = _lastKnownGPSPose.isValid() &&
+                    _lastKnownGPSPose.horizontalAccuracy > 0 &&
+                    _lastKnownGPSPose.horizontalAccuracy < kVROGeospatialAccuracyThresholdMeters;
+    return accurate ? VROEarthTrackingState::Enabled
+                    : VROEarthTrackingState::Localizing;
   }
 #endif
   if (_cloudAnchorProviderARCore) {
@@ -1777,6 +1821,13 @@ VROGeospatialPose VROARSessioniOS::getCameraGeospatialPose() const {
     return [_cloudAnchorProviderARCore getCameraGeospatialPose];
   }
   return VROGeospatialPose();
+}
+
+bool VROARSessioniOS::isLocationAccuracyReduced() const {
+  if (_rvLocationDelegate) {
+    return ((VROLocationDelegate *)_rvLocationDelegate).reducedAccuracy;
+  }
+  return false;
 }
 
 void VROARSessioniOS::checkVPSAvailability(double latitude, double longitude,
@@ -2426,6 +2477,34 @@ static std::string rvCloudAnchorToJson(const ReactVisionCCA::CloudAnchorRecord& 
     return j;
 }
 #endif // RVCCA_AVAILABLE
+
+void VROARSessioniOS::rvStartScan() {
+#if RVCCA_AVAILABLE
+  auto p = [_cloudAnchorProviderRV cppProvider];
+  if (p) {
+    p->startScan();
+  }
+#endif
+}
+
+void VROARSessioniOS::rvFinishScan(
+    int ttlDays,
+    std::function<void(bool, std::string, std::string)> callback) {
+#if RVCCA_AVAILABLE
+  auto p = [_cloudAnchorProviderRV cppProvider];
+  if (p) {
+    p->finishScan(ttlDays,
+        [callback](const std::string& cloudAnchorId) {
+          if (callback) callback(true, cloudAnchorId, "");
+        },
+        [callback](const std::string& error, ReactVisionCCA::RVCCACloudAnchorProvider::ErrorCode) {
+          if (callback) callback(false, "", error);
+        });
+    return;
+  }
+#endif
+  if (callback) callback(false, "", "ReactVision cloud anchor provider not available");
+}
 
 void VROARSessioniOS::rvGetCloudAnchor(
     const std::string& anchorId,

--- a/ios/ViroKit/VROARSessioniOS.h
+++ b/ios/ViroKit/VROARSessioniOS.h
@@ -203,7 +203,7 @@ public:
     // Cloud anchor management
     void rvStartScan() override;
     void rvFinishScan(int ttlDays,
-        std::function<void(bool, std::string, std::string)> callback) override;
+        std::function<void(bool, std::string, std::string, std::string)> callback) override;
     void rvGetCloudAnchor(const std::string& anchorId,
         std::function<void(bool, std::string, std::string)> callback) override;
     void rvListCloudAnchors(int limit, int offset,

--- a/ios/ViroKit/VROARSessioniOS.h
+++ b/ios/ViroKit/VROARSessioniOS.h
@@ -161,6 +161,7 @@ public:
     void setGeospatialModeEnabled(bool enabled) override;
     VROEarthTrackingState getEarthTrackingState() const override;
     VROGeospatialPose getCameraGeospatialPose() const override;
+    bool isLocationAccuracyReduced() const override;
     void checkVPSAvailability(double latitude, double longitude,
                               std::function<void(VROVPSAvailability)> callback) override;
     void createGeospatialAnchor(double latitude, double longitude, double altitude,
@@ -200,6 +201,9 @@ public:
         std::function<void(bool, std::string, std::string)> callback) override;
 
     // Cloud anchor management
+    void rvStartScan() override;
+    void rvFinishScan(int ttlDays,
+        std::function<void(bool, std::string, std::string)> callback) override;
     void rvGetCloudAnchor(const std::string& anchorId,
         std::function<void(bool, std::string, std::string)> callback) override;
     void rvListCloudAnchors(int limit, int offset,

--- a/ios/ViroKit/VROGeospatial.h
+++ b/ios/ViroKit/VROGeospatial.h
@@ -35,8 +35,16 @@
 enum class VROEarthTrackingState {
     Enabled,    // Earth is being tracked with VPS/GPS fusion
     Paused,     // Tracking is paused (e.g., app backgrounded)
-    Stopped     // No tracking available
+    Stopped,    // No tracking available
+    // WS-D: appended, not inserted — Android's JNI bridge maps this enum to Java
+    // by raw ordinal (ARScene.java), so existing positions must not shift.
+    Localizing  // GPS fix acquired but not yet within the accuracy threshold
 };
+
+// WS-D: horizontal accuracy (meters) below which a GPS-only geospatial pose is
+// considered localized rather than still converging. Placeholder default —
+// will become app-configurable via the JS bridge (WS-D follow-up task).
+constexpr double kVROGeospatialAccuracyThresholdMeters = 15.0;
 
 /*
  * Represents the availability of Visual Positioning System (VPS) at a location.
@@ -159,6 +167,7 @@ inline std::string VROEarthTrackingStateToString(VROEarthTrackingState state) {
         case VROEarthTrackingState::Enabled: return "ENABLED";
         case VROEarthTrackingState::Paused: return "PAUSED";
         case VROEarthTrackingState::Stopped: return "STOPPED";
+        case VROEarthTrackingState::Localizing: return "LOCALIZING";
     }
     return "UNKNOWN";
 }


### PR DESCRIPTION
This pull request introduces new APIs and functionality for room/building-scale AR mesh scanning, serialization, and static mesh attachment, as well as improvements to geospatial tracking accuracy and JNI integration. The changes enable capturing, serializing, and restoring AR world meshes for use as persistent cloud anchor assets, and add support for reduced location accuracy states.

**Room/Building-Scale Mesh Scanning and Serialization:**

* Added new APIs to `VROARSession` for starting and finishing a room/building-scale scan (`rvStartScan`, `rvFinishScan`), and corresponding JNI/Java bridge methods to support these operations. (`ViroRenderer/VROARSession.h` [[1]](diffhunk://#diff-64f69eb694177c3488b6b6bb34db64a5226c5166dc253abda629096ae5592f9aR608-R625) `android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp` [[2]](diffhunk://#diff-ab21083c652dbf10094503c4dd6e483cd5950fd8c4aef2be1f0133b1c4bcc630R685-R744) [[3]](diffhunk://#diff-ab21083c652dbf10094503c4dd6e483cd5950fd8c4aef2be1f0133b1c4bcc630R1500-R1512)
* Implemented custom binary serialization and deserialization of AR world meshes in `VROARWorldMesh` for efficient storage and transfer as cloud anchor assets (`serializeCurrentMesh`, `loadMeshSnapshot`). (`ViroRenderer/VROARWorldMesh.cpp` [[1]](diffhunk://#diff-d97126226054b554b73ca8f0e822ed288f3c1701d0cccccceb403046ee994996R486-R726) `ViroRenderer/VROARWorldMesh.h` [[2]](diffhunk://#diff-b6a2ebb219ea6cc7b359511ada0b45e66d184685be91132650dbcfcda0e4dd10R236-R313)

**Static Mesh Attachment and Occlusion:**

* Added support for attaching a resolved (static) mesh to the AR scene, including both physics (collision) and invisible depth-only visual occlusion geometry, ensuring virtual objects are correctly occluded by the real-world mesh. (`ViroRenderer/VROARWorldMesh.cpp` [[1]](diffhunk://#diff-d97126226054b554b73ca8f0e822ed288f3c1701d0cccccceb403046ee994996R486-R726) `ViroRenderer/VROARWorldMesh.h` [[2]](diffhunk://#diff-b6a2ebb219ea6cc7b359511ada0b45e66d184685be91132650dbcfcda0e4dd10R236-R313)

**Geospatial Tracking and Location Accuracy:**

* Added a new `Localizing` state to `VROEarthTrackingState` to represent when GPS is acquired but not yet accurate, and defined a horizontal accuracy threshold constant. (`ViroRenderer/VROGeospatial.h` [[1]](diffhunk://#diff-6e7fec10ac78be17e21f485eeefddbdf874544ad44e93bbba358db26defe4cbeL38-R48) [[2]](diffhunk://#diff-6e7fec10ac78be17e21f485eeefddbdf874544ad44e93bbba358db26defe4cbeR170)
* Added `isLocationAccuracyReduced()` to `VROARSession` to detect when only reduced/approximate device location is available (e.g., iOS "Precise Location" off). (`ViroRenderer/VROARSession.h` [ViroRenderer/VROARSession.hR446-R456](diffhunk://#diff-64f69eb694177c3488b6b6bb34db64a5226c5166dc253abda629096ae5592f9aR446-R456))

**JNI/Platform Integration:**

* Extended JNI bridge code to support the new scan APIs and mesh serialization, including matrix-to-CSV conversion for passing transforms between C++ and Java. (`android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp` [[1]](diffhunk://#diff-ab21083c652dbf10094503c4dd6e483cd5950fd8c4aef2be1f0133b1c4bcc630R685-R744) [[2]](diffhunk://#diff-ab21083c652dbf10094503c4dd6e483cd5950fd8c4aef2be1f0133b1c4bcc630R1500-R1512)

**Dependency and Header Updates:**

* Updated includes in `VROARWorldMesh.cpp` and `VROARWorldMesh.h` to support new mesh, scene, and geometry functionality. (`ViroRenderer/VROARWorldMesh.cpp` [[1]](diffhunk://#diff-d97126226054b554b73ca8f0e822ed288f3c1701d0cccccceb403046ee994996R34-R47) `ViroRenderer/VROARWorldMesh.h` [[2]](diffhunk://#diff-b6a2ebb219ea6cc7b359511ada0b45e66d184685be91132650dbcfcda0e4dd10R37-R45)