### PR TITLE
Quest input: per-ray drag ownership, unselectable aim lasers, click g…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+### Fixed
+
+- **Quest: dragging with both hands tracked followed the wrong hand and jumped on grab (`VROInputControllerBase`).** Hover and click were source-aware but drag still ran off the shared single-pointer slot, so with two aim rays dispatched per frame a drag was seeded from whichever ray was mirrored last (the left) and then moved by both rays in turn, rendering the idle hand's result; any hand's ClickUp ended it. A `VRODraggedObject` now records the ray that started it and that ray's pose, only that ray moves or ends the drag, the original hit is snapshotted at ClickDown, and a second button during a drag neither restarts nor steals it. Grip, A/X/Y and thumbstick sources resolve their hit, hover and drag state through their hand's aim ray via the new `rayForSource()` hook (`VROInputControllerOpenXR`), so a right-grip grab no longer acts on what the left hand points at. Single-pointer backends (AR, Cardboard, Daydream) keep the identity mapping and are unchanged.
+- **Quest: a click on a highlighted button was dropped several times a second (`VROInputPresenterOpenXR`, `VROInputControllerBase`, `VROInputControllerOpenXR`).** The aim-laser nodes were ordinary selectable scene geometry whose bounding box spans controller to hit point, so the hand's own ray hit its laser before the button on a large share of frames; hover hysteresis hid the churn but every click on such a frame resolved to nothing. Lasers and the presenter root are now unselectable. Clicks also get their own grace: the click follows the highlighted node while a hover exit is pending (the old re-route required the miss to land on another hoverable node, which a panel body or the background never is), or the node the ray left within the last 150 ms when the hit is not clickable; the comparison uses bubbled handler nodes, so `Clicked` fires for a press and release on different children of one handler. ClickUp is delivered to the node that took the ClickDown from the same button (press capture). On OpenXR, button and gesture edges are queued and flushed after the frame's hit update instead of resolving against the previous frame's hit.
+
 ## v2.58.1 — 17 August 2026
 
 ### Fixed

--- a/ViroRenderer/VROInputControllerBase.cpp
+++ b/ViroRenderer/VROInputControllerBase.cpp
@@ -81,23 +81,29 @@ void VROInputControllerBase::setProjection(VROMatrix4f projection) {
 }
 
 void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickState clickState) {
-    // Resolve the click against this source's most recent hit result so two
-    // simultaneous pointers don't clobber each other. Falls back to the
-    // legacy `_hitResult` for single-pointer backends.
-    auto hit = getHitResultForSource(source);
+    // Resolve the click against the hit of the ray that carries this source
+    // (a grip shares its hand's aim ray) so two simultaneous pointers don't
+    // clobber each other. Falls back to the legacy `_hitResult` for
+    // single-pointer backends.
+    int ray = rayForSource(source);
+    auto hit = getHitResultForSource(ray);
     if (hit == nullptr) {
         return;
     }
-    bool sourceAware = _hitResultsBySource.count(source) > 0;
+    bool sourceAware = _hitResultsBySource.count(ray) > 0;
+    // Click completion stays per button; hover state belongs to the ray.
     std::shared_ptr<VRONode> &lastClicked = sourceAware
         ? _lastClickedNodesBySource[source]
         : _lastClickedNode;
     std::shared_ptr<VRONode> &lastHovered = sourceAware
-        ? _lastHoveredNodesBySource[source]
+        ? _lastHoveredNodesBySource[ray]
         : _lastHoveredNode;
     HoverPending &pending = sourceAware
-        ? _hoverPendingBySource[source]
+        ? _hoverPendingBySource[ray]
         : _hoverPending;
+    HoverExit &lastExit = sourceAware
+        ? _hoverExitBySource[ray]
+        : _hoverExit;
 
     VROVector3f hitLoc = hit->getLocation();
     std::vector<float> pos = {hitLoc.x, hitLoc.y, hitLoc.z};
@@ -105,63 +111,80 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
         pos.clear();
     }
 
-    // Hover-hysteresis stickiness: if the user pulled the trigger while the
-    // ray-cast was momentarily jittered off the target — i.e. a hover
-    // pending-exit window is still open and the current hit does not land
-    // on `lastHovered` — re-route the click to `lastHovered`. From the
-    // user's perspective they are still pointing at the last hovered
-    // node; the raycast just blinked off for 1–3 frames. Without this,
-    // the trigger pull resolved against background and JS callers had to
-    // press "dozens of times" to land a single click.
     std::shared_ptr<VRONode> hitNode = hit->getNode();
-    if (lastHovered != nullptr &&
-        hitNode != lastHovered &&
-        pending.candidateNode != nullptr &&
-        pending.startedMillis >= 0 &&
-        (VROTimeCurrentMillis() - pending.startedMillis) < kHoverHysteresisMillis) {
-        hitNode = lastHovered;
-        pos.clear();  // we don't retain the on-target hit position; payload
-                      // shape matches a background hit. Handlers usually
-                      // care about source / clickState, not position.
+    std::shared_ptr<VRONode> focusedNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, hitNode);
+
+    // Click grace (see kClickGraceMillis). Compares bubbled handler nodes: the
+    // raw hit is a child quad or glyph and differs from the handler even when
+    // the ray is squarely on target. A miss onto a node with no hover handler
+    // (panel body, background) leaves pending.candidateNode null, so that is
+    // deliberately not a condition here.
+    double now = VROTimeCurrentMillis();
+    std::shared_ptr<VRONode> sticky;
+    if (lastHovered != nullptr && pending.startedMillis >= 0 &&
+        (now - pending.startedMillis) < kClickGraceMillis) {
+        sticky = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, lastHovered);
+    } else if (focusedNode == nullptr && lastExit.node != nullptr &&
+               (now - lastExit.leftMillis) < kClickGraceMillis) {
+        sticky = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, lastExit.node);
+    }
+    bool rerouted = sticky != nullptr && sticky != focusedNode;
+    if (rerouted) {
+        focusedNode = sticky;
+        pos.clear();  // the hit position is off the node; payload shape matches a background hit
     }
 
-    // Notify internal delegates
-    std::shared_ptr<VRONode> focusedNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnClick, hitNode);
+    // Press capture: ClickUp goes to the node that took this button's
+    // ClickDown; Clicked fires only when the release still resolves there.
+    bool completed = false;
+    if (clickState == VROEventDelegate::ClickUp && lastClicked != nullptr) {
+        completed = (focusedNode == lastClicked);
+        if (!completed) {
+            focusedNode = lastClicked;
+            pos.clear();
+        }
+    }
+
     for (std::shared_ptr<VROEventDelegate> delegate : _delegates) {
         delegate->onClick(source, focusedNode, clickState, pos);
     }
-    if (focusedNode != nullptr) {
+    if (focusedNode != nullptr && focusedNode->getEventDelegate()) {
         focusedNode->getEventDelegate()->onClick(source, focusedNode, clickState, pos);
     }
 
-    /*
-     If we have completed a ClickUp and ClickDown event sequentially for a
-     given Node and source, trigger an onClicked event.
-     */
     if (clickState == VROEventDelegate::ClickUp) {
-        if (hitNode == lastClicked) {
+        if (completed) {
             for (std::shared_ptr<VROEventDelegate> delegate : _delegates){
                 delegate->onClick(source, focusedNode, VROEventDelegate::ClickState::Clicked, pos);
             }
-            if (focusedNode != nullptr && focusedNode->getEventDelegate() && lastClicked != nullptr) {
+            if (focusedNode->getEventDelegate()) {
                 focusedNode->getEventDelegate()->onClick(source, focusedNode,
                                                          VROEventDelegate::ClickState::Clicked,
                                                          pos);
             }
         }
         lastClicked = nullptr;
-        if (_lastDraggedNode != nullptr) {
+        // Only the owning ray ends a drag (grip-start / trigger-release on the
+        // same hand still counts); the idle hand's release must not drop it.
+        if (_lastDraggedNode != nullptr &&
+            (_lastDraggedNode->_source == kUnownedSource || _lastDraggedNode->_source == ray)) {
             _lastDraggedNode->_dragState = VROEventDelegate::DragState::End;
             _lastDraggedNode->_draggedNode->setIsBeingDragged(false);
+            _lastDraggedNode = nullptr;
         }
-        _lastDraggedNode = nullptr;
     } else if (clickState == VROEventDelegate::ClickDown){
-        lastClicked = hitNode;
+        lastClicked = focusedNode;
+
+        // A second button during a drag neither restarts it (the frozen hit
+        // would re-seed it with a stale offset) nor lets another ray steal it.
+        if (_lastDraggedNode != nullptr) {
+            return;
+        }
 
         // Identify if object is draggable.
         std::shared_ptr<VRONode> draggableNode
                 = getNodeToHandleEvent(VROEventDelegate::EventAction::OnDrag,
-                                       hitNode);
+                                       rerouted ? focusedNode : hitNode);
         
         if (draggableNode == nullptr){
             return;
@@ -179,6 +202,15 @@ void VROInputControllerBase::onButtonEvent(int source, VROEventDelegate::ClickSt
         draggedObject->_originalDraggedNodePosition = draggableNode->getWorldPosition();
         draggedObject->_originalDraggedNodeRotation = draggableNode->getWorldRotation();
         draggedObject->_draggedNode = draggableNode;
+        // Snapshot this ray's hit now: by the time the owning onMove reaches
+        // processDragging, the shared _hitResult may be the other hand's. A
+        // re-routed click's hit is off the node (possibly the far background),
+        // so anchor that case at the node instead.
+        draggedObject->_originalHitLocation = rerouted ? draggableNode->getWorldPosition()
+                                                       : hit->getLocation();
+        draggedObject->_source = sourceAware ? ray : kUnownedSource;
+        draggedObject->_position = _lastKnownPosition;
+        draggedObject->_forward = _lastKnownForward;
         _lastDraggedNode = draggedObject;
         _lastDraggedNode->_dragState = VROEventDelegate::DragState::Start;
         draggableNode->setIsBeingDragged(true);
@@ -231,9 +263,15 @@ void VROInputControllerBase::onMove(int source, VROVector3f position, VROQuatern
                                                 _lastKnownPosition, _lastKnownForward);
     }
     
-    // Update draggable objects if needed unless we have a pinch motion.
+    // Update draggable objects if needed unless we have a pinch motion. Only
+    // the owning ray moves the node; with two hands tracked the other ray's
+    // onMove would otherwise overwrite the transform every frame.
     if (_lastDraggedNode != nullptr && ((_currentPinchedNode == nullptr) && (_currentRotateNode == nullptr))) {
-        processDragging(source);
+        if (_lastDraggedNode->_source == kUnownedSource || _lastDraggedNode->_source == source) {
+            _lastDraggedNode->_position = position;
+            _lastDraggedNode->_forward = forward;
+            processDragging(source);
+        }
     }
 }
 
@@ -243,7 +281,7 @@ void VROInputControllerBase::processDragging(int source) {
     // Calculate starting pre-drag properties if needed (hit locations, offsets, etc).
     if (_lastDraggedNode->_dragState == VROEventDelegate::DragState::Start) {
         if (draggedNode->getDragType() == VRODragType::FixedDistanceOrigin) {
-            _lastDraggedNode->_draggedDistanceFromController = draggedNode->getWorldPosition().distanceAccurate(_lastKnownPosition);
+            _lastDraggedNode->_draggedDistanceFromController = draggedNode->getWorldPosition().distanceAccurate(_lastDraggedNode->_position);
             _lastDraggedNode->_originalHitLocation = draggedNode->getWorldPosition();
         } else if (draggedNode->getDragType() == VRODragType::FixedToPlane) {
             _lastDraggedNode->_originalHitLocation = getPlaneIntersect(draggedNode);
@@ -258,8 +296,8 @@ void VROInputControllerBase::processDragging(int source) {
                 _lastDraggedNode->_originalDraggedNodePosition = _lastDraggedNode->_originalHitLocation;
             }
         } else {
-            _lastDraggedNode->_draggedDistanceFromController = _hitResult->getLocation().distanceAccurate(_lastKnownPosition);
-            _lastDraggedNode->_originalHitLocation = _hitResult->getLocation();
+            // _originalHitLocation was snapshotted from the owning ray at ClickDown.
+            _lastDraggedNode->_draggedDistanceFromController = _lastDraggedNode->_originalHitLocation.distanceAccurate(_lastDraggedNode->_position);
         }
 
         // Grab the forwardOffset (delta from the controller's forward in reference to the user).
@@ -310,10 +348,10 @@ void VROInputControllerBase::processDragging(int source) {
 
 VROVector3f VROInputControllerBase::getDragPositionFixedDistance() {
     // This is the forward plus the offset from the camera to the controller
-    VROVector3f adjustedForward = _lastKnownForward + _lastDraggedNode->_forwardOffset;
+    VROVector3f adjustedForward = _lastDraggedNode->_forward + _lastDraggedNode->_forwardOffset;
 
-    // camera position + adjustedForward scaled by the distanceFromController (to maintain fixed distance)
-    VROVector3f dragPositionWorld = _lastKnownPosition + (adjustedForward * _lastDraggedNode->_draggedDistanceFromController);
+    // controller position + adjustedForward scaled by the distanceFromController (to maintain fixed distance)
+    VROVector3f dragPositionWorld = _lastDraggedNode->_position + (adjustedForward * _lastDraggedNode->_draggedDistanceFromController);
 
     // The offset is the new drag location minus the original HitTest location
     VROVector3f draggedOffset = dragPositionWorld - _lastDraggedNode->_originalHitLocation;
@@ -335,32 +373,32 @@ VROVector3f VROInputControllerBase::getPlaneIntersect(std::shared_ptr<VRONode> n
 
     // Find the intersection between the plane and the controller forward
     VROVector3f intersectionPoint;
-    bool success = _lastKnownForward.rayIntersectPlane(planePoint, planeNormal,
-                                                       _lastKnownPosition, &intersectionPoint);
+    bool success = _lastDraggedNode->_forward.rayIntersectPlane(planePoint, planeNormal,
+                                                       _lastDraggedNode->_position, &intersectionPoint);
 
     // if there wasn't an intersection point OR the intersectionPoint was too far from the controller's
     // position, then we want to compute the plane position at maxDistance from the controller's
     // position along the controller's forward. (this is the circle you get b/t intersection of a
     // sphere and a plane).
-    if (!success || intersectionPoint.distance(_lastKnownPosition) > maxDistance) {
+    if (!success || intersectionPoint.distance(_lastDraggedNode->_position) > maxDistance) {
 
         // first, project the controller's position onto the plane
         VROVector3f controllerProj;
-        success = _lastKnownPosition.projectOnPlane(planePoint, planeNormal, &controllerProj);
+        success = _lastDraggedNode->_position.projectOnPlane(planePoint, planeNormal, &controllerProj);
         if (!success) {
             return node->getPosition();
         }
 
         // second, project the controller's position + forward onto the plane
         VROVector3f forwardProj;
-        success = _lastKnownPosition.add(_lastKnownForward).projectOnPlane(planePoint, planeNormal, &forwardProj);
+        success = _lastDraggedNode->_position.add(_lastDraggedNode->_forward).projectOnPlane(planePoint, planeNormal, &forwardProj);
         if (!success) {
             return node->getPosition();
         }
 
         // find the length of the 3rd side of the right handed triangle formed by the controller's
         // position, it's projected point, and the position on the plane "maxDistance" from the controller
-        float length = sqrtf(powf(maxDistance, 2) - (powf(_lastKnownPosition.distance(controllerProj), 2)));
+        float length = sqrtf(powf(maxDistance, 2) - (powf(_lastDraggedNode->_position.distance(controllerProj), 2)));
 
         // finally, calculate the intersection point b/t the plane and sphere along the user's forward
         intersectionPoint = controllerProj.add(forwardProj.subtract(controllerProj).normalize().scale(length));
@@ -442,13 +480,13 @@ void VROInputControllerBase::updateHitNode(int source, const VROCamera &camera,
     auto hit = std::make_shared<VROHitTestResult>(hitTest(camera, origin, ray, true));
     _hitResultsBySource[source] = hit;
     // Mirror to the legacy single-source slot so subsystems that don't carry
-    // a source ID (drag, fuse, pinch, rotate) keep functioning.
+    // a source ID (fuse, pinch, rotate) keep functioning.
     _hitResult = hit;
 }
 
 std::shared_ptr<VROHitTestResult>
 VROInputControllerBase::getHitResultForSource(int source) const {
-    auto it = _hitResultsBySource.find(source);
+    auto it = _hitResultsBySource.find(rayForSource(source));
     if (it != _hitResultsBySource.end() && it->second) {
         return it->second;
     }
@@ -519,6 +557,9 @@ void VROInputControllerBase::processGazeEvent(int source) {
     HoverPending &pending = sourceAware
         ? _hoverPendingBySource[source]
         : _hoverPending;
+    HoverExit &lastExit = sourceAware
+        ? _hoverExitBySource[source]
+        : _hoverExit;
 
     std::shared_ptr<VRONode> newNode = getNodeToHandleEvent(VROEventDelegate::EventAction::OnHover,
                                                                 hit->getNode());
@@ -578,6 +619,8 @@ void VROInputControllerBase::processGazeEvent(int source) {
     if (lastHovered && lastHovered->getEventDelegate()) {
         lastHovered->getEventDelegate()->onHover(source, lastHovered, false, pos);
     }
+    lastExit.node = lastHovered;
+    lastExit.leftMillis = pending.startedMillis;
     lastHovered = newNode;
     pending = HoverPending{};
 }

--- a/ViroRenderer/VROInputControllerBase.h
+++ b/ViroRenderer/VROInputControllerBase.h
@@ -183,7 +183,7 @@ protected:
 
     /*
      Source-aware hit-node update. Stores the result both in the legacy
-     `_hitResult` (so single-pointer subsystems — drag, fuse, pinch, rotate —
+     `_hitResult` (so single-pointer subsystems — fuse, pinch, rotate —
      keep working unchanged) and in `_hitResultsBySource[source]` so that
      gaze/click events can resolve against the specific input source that
      produced them. Used by backends with multiple simultaneous pointers
@@ -193,10 +193,17 @@ protected:
                        VROVector3f origin, VROVector3f ray);
 
     /*
-     Returns the per-source hit result if one was recorded for this source,
-     otherwise falls back to the legacy single-source `_hitResult`.
+     Returns the per-source hit result recorded for this source's ray (see
+     rayForSource), otherwise falls back to the legacy single-source `_hitResult`.
      */
     std::shared_ptr<VROHitTestResult> getHitResultForSource(int source) const;
+
+    /*
+     Maps a button source onto the source whose aim ray hit-tests for it, so a
+     grip or face button resolves against its own hand's hit, hover and drag
+     state. Identity by default (single-pointer backends).
+     */
+    virtual int rayForSource(int source) const { return source; }
 
     /*
      VRODraggedObject encapsulates all the information that needs to be tracked
@@ -210,7 +217,22 @@ protected:
         VROVector3f _forwardOffset;
         float _draggedDistanceFromController;
         VROEventDelegate::DragState _dragState;
+
+        /*
+         Ray (see rayForSource) that started the drag and alone may move or end
+         it. kUnownedSource on single-pointer backends, whose button and ray
+         report under different source ids.
+         */
+        int _source;
+
+        /*
+         Owning ray's latest pose. Drag math reads these rather than the shared
+         _lastKnown*, which the other hand overwrites every frame.
+         */
+        VROVector3f _position;
+        VROVector3f _forward;
     };
+    static constexpr int kUnownedSource = -1;
     
     /*
      Last hit result that we are performing a drag event on.
@@ -235,8 +257,8 @@ protected:
 
     /*
      Returns the position of the intersection point on the given node's configured fixed
-     plane, based on a rayIntersectPlane test performed from the _lastKnownPosition in
-     the direction of _lastKnownForward.
+     plane, based on a rayIntersectPlane test performed from the owning ray's pose stored
+     on _lastDraggedNode.
      */
     VROVector3f getPlaneIntersect(std::shared_ptr<VRONode> node);
 
@@ -374,6 +396,21 @@ private:
     };
     std::map<int, HoverPending> _hoverPendingBySource;
     HoverPending _hoverPending;  // legacy single-source fallback
+
+    /*
+     Clicks get a longer grace than hover exits: the press motion tilts the
+     aim by 1–3°, about the height of a small button at arm's length. While
+     a hover exit is pending the click follows the highlight; once the exit
+     is confirmed, a click that hits nothing clickable still goes to the node
+     the ray left less than kClickGraceMillis ago.
+     */
+    static constexpr double kClickGraceMillis = 150.0;
+    struct HoverExit {
+        std::shared_ptr<VRONode> node;   // last node whose hover exit was confirmed
+        double leftMillis = -1.0;        // when the ray first left it
+    };
+    std::map<int, HoverExit> _hoverExitBySource;
+    HoverExit _hoverExit;  // legacy single-source fallback
 
     /*
      Returns the first node that is able to handle the event action by bubbling it up.

--- a/ViroRenderer/VROInputPresenter.h
+++ b/ViroRenderer/VROInputPresenter.h
@@ -49,6 +49,8 @@ public:
     VROInputPresenter() : VROThreadRestricted(VROThreadName::Renderer) {
         _reticle = nullptr;
         _rootNode = std::make_shared<VRONode>();
+        // Presenter geometry (lasers, controller models) is never a hit target.
+        _rootNode->setSelectable(false);
     }
 
     ~VROInputPresenter() {}

--- a/android/sharedCode/src/main/cpp/VROInputControllerOpenXR.cpp
+++ b/android/sharedCode/src/main/cpp/VROInputControllerOpenXR.cpp
@@ -345,9 +345,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState >= kTriggerThreshold);
             if (pressed && !_prevTriggerRight)
-                VROInputControllerBase::onButtonEvent(ViroOculus::Controller, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::Controller, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevTriggerRight)
-                VROInputControllerBase::onButtonEvent(ViroOculus::Controller, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::Controller, VROEventDelegate::ClickState::ClickUp);
             _prevTriggerRight = pressed;
         }
     }
@@ -361,9 +361,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState >= kTriggerThreshold);
             if (pressed && !_prevTriggerLeft)
-                VROInputControllerBase::onButtonEvent(ViroOculus::LeftController, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::LeftController, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevTriggerLeft)
-                VROInputControllerBase::onButtonEvent(ViroOculus::LeftController, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::LeftController, VROEventDelegate::ClickState::ClickUp);
             _prevTriggerLeft = pressed;
         }
     }
@@ -377,9 +377,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState >= kGripThreshold);
             if (pressed && !_prevGripRight)
-                VROInputControllerBase::onButtonEvent(ViroOculus::RightGrip, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::RightGrip, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevGripRight)
-                VROInputControllerBase::onButtonEvent(ViroOculus::RightGrip, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::RightGrip, VROEventDelegate::ClickState::ClickUp);
             _prevGripRight = pressed;
         }
     }
@@ -393,9 +393,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState >= kGripThreshold);
             if (pressed && !_prevGripLeft)
-                VROInputControllerBase::onButtonEvent(ViroOculus::LeftGrip, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::LeftGrip, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevGripLeft)
-                VROInputControllerBase::onButtonEvent(ViroOculus::LeftGrip, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::LeftGrip, VROEventDelegate::ClickState::ClickUp);
             _prevGripLeft = pressed;
         }
     }
@@ -409,9 +409,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState == XR_TRUE);
             if (pressed && !_prevAButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::AButton, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::AButton, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevAButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::AButton, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::AButton, VROEventDelegate::ClickState::ClickUp);
             _prevAButton = pressed;
         }
     }
@@ -425,10 +425,10 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState == XR_TRUE);
             if (pressed && !_prevBButton) {
-                VROInputControllerBase::onButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickDown);
                 if (_backButtonCallback) _backButtonCallback();
             } else if (!pressed && _prevBButton) {
-                VROInputControllerBase::onButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickUp);
             }
             _prevBButton = pressed;
         }
@@ -443,9 +443,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState == XR_TRUE);
             if (pressed && !_prevXButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::XButton, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::XButton, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevXButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::XButton, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::XButton, VROEventDelegate::ClickState::ClickUp);
             _prevXButton = pressed;
         }
     }
@@ -459,9 +459,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState == XR_TRUE);
             if (pressed && !_prevYButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::YButton, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::YButton, VROEventDelegate::ClickState::ClickDown);
             else if (!pressed && _prevYButton)
-                VROInputControllerBase::onButtonEvent(ViroOculus::YButton, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::YButton, VROEventDelegate::ClickState::ClickUp);
             _prevYButton = pressed;
         }
     }
@@ -475,10 +475,10 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
         if (state.isActive) {
             bool pressed = (state.currentState == XR_TRUE);
             if (pressed && !_prevMenuButton) {
-                VROInputControllerBase::onButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickDown);
                 if (_backButtonCallback) _backButtonCallback();
             } else if (!pressed && _prevMenuButton) {
-                VROInputControllerBase::onButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(ViroOculus::BackButton, VROEventDelegate::ClickState::ClickUp);
             }
             _prevMenuButton = pressed;
         }
@@ -551,9 +551,9 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
 
     // ── Per-source dispatch — both hands handled independently ──────────────
     // Each side calls the source-aware updateHitNode so its hit/hover/click
-    // state is tracked separately in VROInputControllerBase. Pinch / trigger
-    // edge events emitted earlier in this frame already carry the correct
-    // source, so onButtonEvent will resolve against this side's hit result.
+    // state is tracked separately in VROInputControllerBase. Button edges
+    // polled earlier this frame are flushed after this, so they resolve
+    // against these hits rather than the previous frame's.
     auto dispatchSide = [this, &camera](
         bool valid, int source,
         const VROVector3f &pos, const VROQuaternion &rot, const VROVector3f &fwd) {
@@ -587,6 +587,11 @@ void VROInputControllerOpenXR::onProcess(XrSession session, XrSpace baseSpace,
             VROInputControllerBase::processGazeEvent(ViroOculus::EyeGaze);
         }
     }
+
+    for (const auto &edge : _pendingButtons) {
+        VROInputControllerBase::onButtonEvent(edge.first, edge.second);
+    }
+    _pendingButtons.clear();
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -781,9 +786,9 @@ void VROInputControllerOpenXR::processHands(XrSpace baseSpace, XrTime time,
             }
         }
         if (pinched && !prevPinch)
-            VROInputControllerBase::onButtonEvent(source, VROEventDelegate::ClickState::ClickDown);
+            queueButtonEvent(source, VROEventDelegate::ClickState::ClickDown);
         else if (!pinched && prevPinch)
-            VROInputControllerBase::onButtonEvent(source, VROEventDelegate::ClickState::ClickUp);
+            queueButtonEvent(source, VROEventDelegate::ClickState::ClickUp);
         prevPinch = pinched;
 
         // ── Grab detection (middle tip to palm distance) ──────────────────────
@@ -797,9 +802,9 @@ void VROInputControllerOpenXR::processHands(XrSpace baseSpace, XrTime time,
             bool grabbed = (sqrtf(dx*dx + dy*dy + dz*dz) < 0.06f);
 
             if (grabbed && !prevGrab)
-                VROInputControllerBase::onButtonEvent(gripSource, VROEventDelegate::ClickState::ClickDown);
+                queueButtonEvent(gripSource, VROEventDelegate::ClickState::ClickDown);
             else if (!grabbed && prevGrab)
-                VROInputControllerBase::onButtonEvent(gripSource, VROEventDelegate::ClickState::ClickUp);
+                queueButtonEvent(gripSource, VROEventDelegate::ClickState::ClickUp);
             prevGrab = grabbed;
         }
     }
@@ -811,6 +816,26 @@ void VROInputControllerOpenXR::processHands(XrSpace baseSpace, XrTime time,
 
 VROVector3f VROInputControllerOpenXR::getDragForwardOffset() {
     return VROVector3f(0, 0, 0);
+}
+
+void VROInputControllerOpenXR::queueButtonEvent(int source, VROEventDelegate::ClickState state) {
+    _pendingButtons.emplace_back(source, state);
+}
+
+int VROInputControllerOpenXR::rayForSource(int source) const {
+    switch (source) {
+        case ViroOculus::AButton:
+        case ViroOculus::RightGrip:
+        case ViroOculus::RightThumbstick:
+            return ViroOculus::Controller;
+        case ViroOculus::XButton:
+        case ViroOculus::YButton:
+        case ViroOculus::LeftGrip:
+        case ViroOculus::LeftThumbstick:
+            return ViroOculus::LeftController;
+        default:
+            return source;
+    }
 }
 
 bool VROInputControllerOpenXR::stickyPose(PersistentAim &state, bool currentValid,

--- a/android/sharedCode/src/main/cpp/VROInputControllerOpenXR.h
+++ b/android/sharedCode/src/main/cpp/VROInputControllerOpenXR.h
@@ -29,6 +29,8 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
+#include <vector>
 #include <openxr/openxr.h>
 #include "VROInputControllerBase.h"
 
@@ -103,7 +105,21 @@ protected:
     std::shared_ptr<VROInputPresenter> createPresenter(
         std::shared_ptr<VRODriver> driver) override;
 
+    /*
+     * Buttons ride their hand's aim ray: grip / A / thumbstick → Controller,
+     * grip / X / Y / thumbstick → LeftController. BackButton is shared by B
+     * and Menu, so it stays unmapped.
+     */
+    int rayForSource(int source) const override;
+
 private:
+    /*
+     * Buttons and gestures are polled before this frame's hit update, so
+     * their edges are queued and flushed at the end of onProcess.
+     */
+    void queueButtonEvent(int source, VROEventDelegate::ClickState state);
+    std::vector<std::pair<int, VROEventDelegate::ClickState>> _pendingButtons;
+
     // ── Action set ────────────────────────────────────────────────────────────
     XrActionSet _actionSet = XR_NULL_HANDLE;
 

--- a/android/sharedCode/src/main/cpp/VROInputPresenterOpenXR.h
+++ b/android/sharedCode/src/main/cpp/VROInputPresenterOpenXR.h
@@ -121,6 +121,10 @@ private:
         laser.node->setName("AimLaser");
         laser.node->setGeometry(laser.geom);
         laser.node->setHidden(true);  // hidden until first updateAimRay()
+        // The beam's AABB spans controller to hit point, so its own ray runs
+        // through it corner to corner and would out-sort the aimed node.
+        laser.node->setSelectable(false);
+        laser.node->setIgnoreEventHandling(true);
         _rootNode->addChildNode(laser.node);
 
         return _lasers.emplace(source, std::move(laser)).first->second;


### PR DESCRIPTION
…race with press capture

A VRODraggedObject records the aim ray that started it and that ray's pose; only the owner moves or ends the drag, the hit is snapshotted at ClickDown, and a second button neither restarts nor steals it. Grip, A/X/Y and thumbstick sources resolve hit, hover and drag through their hand's ray via the rayForSource() hook (identity on single-pointer backends).

The OpenXR laser nodes and the presenter root are unselectable, so the hand's own beam no longer out-sorts the aimed node. Clicks compare bubbled handler nodes, follow the highlighted node while a hover exit is pending or the node the ray left within 150 ms when the hit is not clickable, and ClickUp goes to the node that took the ClickDown. Clicked fires on the handler node. OpenXR button and gesture edges are queued and flushed after the frame's hit update.