### PR TITLE
Co-location: shared frames on Quest, and the channel bridge

### DIFF
--- a/ViroRenderer/VROARSession.h
+++ b/ViroRenderer/VROARSession.h
@@ -647,6 +647,40 @@ public:
     }
 
     // ========================================================================
+    // Shared coordinate frame — platform-native co-location (CL-H / CL-I)
+    //
+    // Distinct from cloud anchors on purpose. A cloud anchor is relocalised from
+    // camera imagery; these frames come from the platform's own co-location
+    // primitive (Meta shared spatial anchors, ARKit shared coordinate spaces),
+    // which is what makes them viable on headsets that give no camera access.
+    //
+    // Both take an app-chosen group id, which is also the room key for the
+    // co-location channel: same group, same room, same frame.
+    //
+    // The callback's transform is 16 comma-separated floats, column-major
+    // (VROMatrix4f::getArray() order) — the same encoding resolveCloudAnchor()
+    // hands back, so consumers treat the two identically.
+
+    /* True when this session can establish a platform-native shared frame. */
+    virtual bool rvSupportsSharedFrame() { return false; }
+
+    /* Establish a frame and publish it to `groupId` for others to join. */
+    virtual void rvCreateSharedFrame(
+        std::string groupId,
+        std::function<void(bool success, std::string frameId,
+                            std::string transformCsv, std::string error)> callback) {
+        if (callback) callback(false, "", "", "Not supported");
+    }
+
+    /* Recover a frame previously published to `groupId` by another device. */
+    virtual void rvJoinSharedFrame(
+        std::string groupId,
+        std::function<void(bool success, std::string frameId,
+                            std::string transformCsv, std::string error)> callback) {
+        if (callback) callback(false, "", "", "Not supported");
+    }
+
+    // ========================================================================
     // ReactVision Geospatial CRUD API
     // These methods route directly to the ReactVision backend and are only
     // meaningful when geospatialAnchorProvider == ReactVision.

--- a/ViroRenderer/VROColocationSession.cpp
+++ b/ViroRenderer/VROColocationSession.cpp
@@ -1,0 +1,151 @@
+//
+//  VROColocationSession.cpp
+//  ViroRenderer
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+
+#include "VROColocationSession.h"
+#include "VROLog.h"
+
+// ReactVisionCCA is optional. Without it this compiles to a holder that always
+// reports unavailable, so an open-source build links and runs — it simply has
+// no channel, exactly like it has no cloud anchors.
+#if __has_include("ReactVisionCCA/RVCCAColocationSession.h")
+#  define VRO_RVCCA_COLOCATION 1
+#  include "ReactVisionCCA/RVCCAColocationSession.h"
+#else
+#  define VRO_RVCCA_COLOCATION 0
+#endif
+
+class VROColocationSession::Impl {
+public:
+#if VRO_RVCCA_COLOCATION
+    std::unique_ptr<ReactVisionCCA::RVCCAColocationSession> session;
+    std::string roomId;
+#endif
+};
+
+VROColocationSession::VROColocationSession() : _impl(new Impl()) {}
+VROColocationSession::~VROColocationSession() = default;
+
+VROColocationSession &VROColocationSession::get() {
+    static VROColocationSession instance;
+    return instance;
+}
+
+bool VROColocationSession::isAvailable() const {
+#if VRO_RVCCA_COLOCATION
+    return ReactVisionCCA::RVCCAColocationSession::isSupported();
+#else
+    return false;
+#endif
+}
+
+void VROColocationSession::join(const std::string &roomId,
+                                 const std::string &apiKey,
+                                 const std::string &projectId,
+                                 const std::string &endpoint,
+                                 std::function<void(bool, std::string)> callback) {
+#if VRO_RVCCA_COLOCATION
+    if (!isAvailable()) {
+        if (callback) callback(false, "Co-location channel unavailable on this platform");
+        return;
+    }
+    if (roomId.empty()) {
+        if (callback) callback(false, "roomId is required");
+        return;
+    }
+    if (apiKey.empty() || projectId.empty()) {
+        if (callback) callback(false, "apiKey and projectId are required");
+        return;
+    }
+
+    ReactVisionCCA::RVCCAColocationSession::Config cfg;
+    cfg.apiKey    = apiKey;
+    cfg.projectId = projectId;
+    if (!endpoint.empty()) cfg.endpoint = endpoint;
+
+    // Rebuilt rather than reused: Config is read at construction, so switching
+    // rooms with a different endpoint or key would otherwise keep the old one.
+    _impl->session.reset(new ReactVisionCCA::RVCCAColocationSession(cfg));
+    _impl->roomId = roomId;
+
+    ReactVisionCCA::RVCCAColocationSession::Callbacks cb;
+    // The channel reports terminal failures through onError and recoverable
+    // drops as Reconnecting, so only the former resolves the join as failed.
+    auto done = std::make_shared<bool>(false);
+    cb.onStateChange = [callback, done](ReactVisionCCA::RVCCAColocationSession::State s) {
+        if (*done) return;
+        if (s == ReactVisionCCA::RVCCAColocationSession::State::Joined) {
+            *done = true;
+            if (callback) callback(true, "");
+        }
+    };
+    cb.onError = [callback, done](const std::string &error) {
+        if (*done) return;
+        *done = true;
+        if (callback) callback(false, error);
+    };
+
+    _impl->session->join(roomId, std::move(cb));
+#else
+    (void)roomId; (void)apiKey; (void)projectId; (void)endpoint;
+    if (callback) callback(false, "ReactVisionCCA is not linked in this build");
+#endif
+}
+
+void VROColocationSession::leave() {
+#if VRO_RVCCA_COLOCATION
+    if (_impl->session) _impl->session->leave();
+    _impl->session.reset();
+    _impl->roomId.clear();
+#endif
+}
+
+void VROColocationSession::setLocalPose(const VROMatrix4f &locationFramePose) {
+#if VRO_RVCCA_COLOCATION
+    if (_impl->session) _impl->session->setLocalPose(locationFramePose);
+#else
+    (void)locationFramePose;
+#endif
+}
+
+VROColocationState VROColocationSession::state() const {
+#if VRO_RVCCA_COLOCATION
+    if (!_impl->session) return VROColocationState::Idle;
+    using S = ReactVisionCCA::RVCCAColocationSession::State;
+    switch (_impl->session->state()) {
+        case S::Idle:         return VROColocationState::Idle;
+        case S::Joining:      return VROColocationState::Joining;
+        case S::Joined:       return VROColocationState::Joined;
+        case S::Reconnecting: return VROColocationState::Reconnecting;
+        case S::Failed:       return VROColocationState::Failed;
+    }
+#endif
+    return VROColocationState::Idle;
+}
+
+std::string VROColocationSession::localPeerId() const {
+#if VRO_RVCCA_COLOCATION
+    if (_impl->session) return _impl->session->localPeerId();
+#endif
+    return "";
+}
+
+std::vector<VROColocationPeer> VROColocationSession::peers() const {
+    std::vector<VROColocationPeer> out;
+#if VRO_RVCCA_COLOCATION
+    if (!_impl->session) return out;
+    for (const auto &p : _impl->session->peers()) {
+        VROColocationPeer peer;
+        peer.peerId      = p.peerId;
+        peer.timestampMs = p.timestampMs;
+        peer.localized   = p.localized;
+        for (int i = 0; i < 3; i++) peer.position[i] = p.position[i];
+        for (int i = 0; i < 4; i++) peer.rotation[i] = p.rotation[i];
+        out.push_back(peer);
+    }
+#endif
+    return out;
+}

--- a/ViroRenderer/VROColocationSession.h
+++ b/ViroRenderer/VROColocationSession.h
@@ -1,0 +1,100 @@
+//
+//  VROColocationSession.h
+//  ViroRenderer
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+//  Platform-neutral holder for the co-location frame channel.
+//
+//  The channel itself lives in ReactVisionCCA (RVCCAColocationSession) and
+//  carries frame-native data — where each peer is, and whether they have
+//  localised — between devices that already share a coordinate frame.
+//
+//  This wrapper exists so the two platform bridges reach it the same way, and
+//  so nothing above has to know whether the proprietary library was linked at
+//  all: without it every call fails cleanly and `isAvailable()` says why.
+//
+//  Deliberately not hung off VROARSession. The channel needs no AR session —
+//  only a room id and poses — and visionOS has no VROARSession to hang it from,
+//  so making it independent is what lets one implementation serve all three
+//  platforms.
+//
+//  One session per process: a device is in one room at a time, and a second
+//  join is a switch, not a second membership.
+//
+
+#ifndef VROColocationSession_h
+#define VROColocationSession_h
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <functional>
+
+#include "VROMatrix4f.h"
+
+/** One peer's last known pose, in the shared location frame. */
+struct VROColocationPeer {
+    std::string peerId;
+    float position[3] = {0, 0, 0};
+    float rotation[4] = {0, 0, 0, 1};   // quaternion x, y, z, w
+    double timestampMs = 0.0;
+    bool   localized = false;
+};
+
+enum class VROColocationState {
+    Idle,
+    Joining,
+    Joined,
+    Reconnecting,
+    Failed
+};
+
+class VROColocationSession {
+public:
+
+    /** The process-wide session. Created on first use. */
+    static VROColocationSession &get();
+
+    /**
+     * False when ReactVisionCCA was not linked, or the platform has no
+     * WebSocket transport. Every other call is a no-op in that case.
+     */
+    bool isAvailable() const;
+
+    /**
+     * Join the room for `roomId` — the cloud anchor id, Meta group id or
+     * visionOS session id that already names the shared frame.
+     *
+     * Leaves any room already joined. `endpoint` may be empty for the default.
+     */
+    void join(const std::string &roomId,
+              const std::string &apiKey,
+              const std::string &projectId,
+              const std::string &endpoint,
+              std::function<void(bool success, std::string error)> callback);
+
+    void leave();
+
+    /**
+     * Publish the local pose, **in the shared location frame** — not world
+     * coordinates, which are per-session and meaningless to the receiver.
+     * Safe to call every frame; the rate limit lives below this.
+     */
+    void setLocalPose(const VROMatrix4f &locationFramePose);
+
+    VROColocationState state() const;
+    std::string localPeerId() const;
+    std::vector<VROColocationPeer> peers() const;
+
+private:
+    VROColocationSession();
+    ~VROColocationSession();
+    VROColocationSession(const VROColocationSession &) = delete;
+    VROColocationSession &operator=(const VROColocationSession &) = delete;
+
+    class Impl;
+    std::unique_ptr<Impl> _impl;
+};
+
+#endif /* VROColocationSession_h */

--- a/android/sharedCode/CMakeLists.txt
+++ b/android/sharedCode/CMakeLists.txt
@@ -60,6 +60,7 @@ add_library( # Sets the name of the library.
              ${VIRO_ANDROID_SRC}/VROSceneRendererOpenXR.cpp
              ${VIRO_ANDROID_SRC}/VROARSessionOpenXR.cpp
              ${VIRO_ANDROID_SRC}/VROARSessionOpenXRSharedFrame.cpp
+             ${VIRO_ANDROID_SRC}/Colocation_JNI.cpp
              ${VIRO_ANDROID_SRC}/VROSceneRendererSceneView.cpp
              ${VIRO_ANDROID_SRC}/VROSample.cpp
              ${VIRO_ANDROID_SRC}/VROImageAndroid.cpp
@@ -196,6 +197,7 @@ add_library( # Sets the name of the library.
              ${VIRO_RENDERER_SRC}/VROBoneConstraint.cpp
              ${VIRO_RENDERER_SRC}/VROTransformConstraint.cpp
              ${VIRO_RENDERER_SRC}/VRORenderer.cpp
+             ${VIRO_RENDERER_SRC}/VROColocationSession.cpp
              ${VIRO_RENDERER_SRC}/VROFrameSynchronizerInternal.cpp
              ${VIRO_RENDERER_SRC}/VROPortalTraversalListener.cpp
              ${VIRO_RENDERER_SRC}/VROGeometrySubstrate.cpp

--- a/android/sharedCode/CMakeLists.txt
+++ b/android/sharedCode/CMakeLists.txt
@@ -59,6 +59,7 @@ add_library( # Sets the name of the library.
              # dependency, which was not 16 KB-page compliant (see viro#491).
              ${VIRO_ANDROID_SRC}/VROSceneRendererOpenXR.cpp
              ${VIRO_ANDROID_SRC}/VROARSessionOpenXR.cpp
+             ${VIRO_ANDROID_SRC}/VROARSessionOpenXRSharedFrame.cpp
              ${VIRO_ANDROID_SRC}/VROSceneRendererSceneView.cpp
              ${VIRO_ANDROID_SRC}/VROSample.cpp
              ${VIRO_ANDROID_SRC}/VROImageAndroid.cpp

--- a/android/sharedCode/src/main/cpp/Colocation_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/Colocation_JNI.cpp
@@ -1,0 +1,132 @@
+//
+//  Colocation_JNI.cpp
+//  ViroRenderer
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+//  JNI surface for the co-location frame channel.
+//
+//  Bound to a plain Java class rather than a scene controller: the channel
+//  needs no AR session, only a room id and poses, so tying it to one would make
+//  it unreachable on the platforms that have no VROARSession.
+//
+
+#include <jni.h>
+#include <string>
+#include <memory>
+
+#include "VROColocationSession.h"
+#include "VROMatrix4f.h"
+#include "VROPlatformUtil.h"
+
+#define VRO_METHOD(return_type, method_name) \
+  JNIEXPORT return_type JNICALL              \
+      Java_com_viro_core_ColocationSession_##method_name
+
+namespace {
+
+std::string toStd(JNIEnv *env, jstring s) {
+    if (!s) return "";
+    const char *c = env->GetStringUTFChars(s, nullptr);
+    std::string out = c ? c : "";
+    if (c) env->ReleaseStringUTFChars(s, c);
+    return out;
+}
+
+/** 16 comma-separated floats, column-major — the encoding every layer uses. */
+bool parseMatrixCsv(const std::string &csv, VROMatrix4f *out) {
+    float v[16];
+    size_t pos = 0;
+    for (int i = 0; i < 16; i++) {
+        size_t comma = csv.find(',', pos);
+        std::string tok = csv.substr(pos, comma == std::string::npos
+                                            ? std::string::npos : comma - pos);
+        try { v[i] = std::stof(tok); } catch (...) { return false; }
+        if (comma == std::string::npos) { if (i != 15) return false; break; }
+        pos = comma + 1;
+    }
+    *out = VROMatrix4f(v);
+    return true;
+}
+
+} // namespace
+
+extern "C" {
+
+VRO_METHOD(jboolean, nativeIsAvailable)(JNIEnv *, jobject) {
+    return VROColocationSession::get().isAvailable() ? JNI_TRUE : JNI_FALSE;
+}
+
+VRO_METHOD(void, nativeJoin)(JNIEnv *env, jobject obj, jstring key_j,
+                             jstring roomId_j, jstring apiKey_j,
+                             jstring projectId_j, jstring endpoint_j) {
+    std::string keyStr    = toStd(env, key_j);
+    std::string roomId    = toStd(env, roomId_j);
+    std::string apiKey    = toStd(env, apiKey_j);
+    std::string projectId = toStd(env, projectId_j);
+    std::string endpoint  = toStd(env, endpoint_j);
+
+    jobject weakObj = env->NewWeakGlobalRef(obj);
+
+    VROColocationSession::get().join(roomId, apiKey, projectId, endpoint,
+        [weakObj, keyStr](bool success, std::string error) {
+            VROPlatformDispatchAsyncApplication([weakObj, keyStr, success, error] {
+                JNIEnv *env = VROPlatformGetJNIEnv();
+                jobject local = env->NewLocalRef(weakObj);
+                if (local == nullptr) {
+                    env->DeleteWeakGlobalRef(weakObj);
+                    return;
+                }
+                jstring jKey = env->NewStringUTF(keyStr.c_str());
+                jstring jErr = env->NewStringUTF(error.c_str());
+                VROPlatformCallHostFunction(local, "onJoinResult",
+                    "(Ljava/lang/String;ZLjava/lang/String;)V",
+                    jKey, (jboolean)success, jErr);
+                env->DeleteLocalRef(local);
+                env->DeleteWeakGlobalRef(weakObj);
+            });
+        });
+}
+
+VRO_METHOD(void, nativeLeave)(JNIEnv *, jobject) {
+    VROColocationSession::get().leave();
+}
+
+VRO_METHOD(void, nativeSetLocalPose)(JNIEnv *env, jobject, jstring csv_j) {
+    VROMatrix4f m;
+    if (!parseMatrixCsv(toStd(env, csv_j), &m)) return;
+    VROColocationSession::get().setLocalPose(m);
+}
+
+VRO_METHOD(jint, nativeGetState)(JNIEnv *, jobject) {
+    return (jint)VROColocationSession::get().state();
+}
+
+VRO_METHOD(jstring, nativeGetLocalPeerId)(JNIEnv *env, jobject) {
+    return env->NewStringUTF(VROColocationSession::get().localPeerId().c_str());
+}
+
+/**
+ * Peers as one flat string rather than an object array.
+ *
+ * Building a String[][] or a parcelable list across JNI costs a local ref per
+ * field and is polled several times a second; one string parsed on the Java
+ * side is cheaper and far less code. Format, semicolon-separated rows:
+ *   peerId,px,py,pz,qx,qy,qz,qw,timestampMs,localized
+ */
+VRO_METHOD(jstring, nativeGetPeers)(JNIEnv *env, jobject) {
+    std::string out;
+    char buf[256];
+    for (const auto &p : VROColocationSession::get().peers()) {
+        if (!out.empty()) out += ';';
+        snprintf(buf, sizeof(buf), "%s,%g,%g,%g,%g,%g,%g,%g,%.0f,%d",
+                 p.peerId.c_str(),
+                 p.position[0], p.position[1], p.position[2],
+                 p.rotation[0], p.rotation[1], p.rotation[2], p.rotation[3],
+                 p.timestampMs, p.localized ? 1 : 0);
+        out += buf;
+    }
+    return env->NewStringUTF(out.c_str());
+}
+
+} // extern "C"

--- a/android/sharedCode/src/main/cpp/VROARSessionOpenXR.cpp
+++ b/android/sharedCode/src/main/cpp/VROARSessionOpenXR.cpp
@@ -195,6 +195,16 @@ bool VROARSessionOpenXR::initSceneDetection(XrInstance instance, XrSession sessi
     }
     _sceneAvailable = true;
     ALOGV("XR_FB_scene initialised (room model from Space Setup)");
+
+    // Shared coordinate frames (CL-H) ride on the same extension family. Loaded
+    // best-effort and separately from `ok`: a runtime without group sharing must
+    // still get the room model, which is the thing most Quest apps actually use.
+    bool sharing = true;
+    sharing &= loadFn("xrCreateSpatialAnchorFB", (void **)&_pfnCreateSpatialAnchor);
+    sharing &= loadFn("xrShareSpacesMETA",       (void **)&_pfnShareSpaces);
+    _sharingAvailable = sharing;
+    ALOGV("shared coordinate frames: %s", sharing ? "available" : "unavailable");
+
     return true;
 }
 
@@ -492,11 +502,27 @@ void VROARSessionOpenXR::onSpatialEvent(const XrEventDataBuffer &event) {
     switch (event.type) {
         case XR_TYPE_EVENT_DATA_SPACE_QUERY_RESULTS_AVAILABLE_FB: {
             auto *ev = reinterpret_cast<const XrEventDataSpaceQueryResultsAvailableFB *>(&event);
-            processSceneQueryResults(ev->requestId);
+            // Both the room-model query and the shared-frame group query land
+            // here; the request id is what tells them apart.
+            if (_sharedFrame.phase == SharedFrameOp::Phase::Querying &&
+                ev->requestId == _sharedFrame.requestId) {
+                processSharedFrameQueryResults(ev->requestId);
+            } else {
+                processSceneQueryResults(ev->requestId);
+            }
             break;
         }
         case XR_TYPE_EVENT_DATA_SPACE_QUERY_COMPLETE_FB: {
             auto *ev = reinterpret_cast<const XrEventDataSpaceQueryCompleteFB *>(&event);
+            if (_sharedFrame.phase == SharedFrameOp::Phase::Querying &&
+                ev->requestId == _sharedFrame.requestId) {
+                // Completing while still in Querying means the results event
+                // never produced a space — nobody has shared to this group yet.
+                finishSharedFrame(false, XR_FAILED(ev->result)
+                    ? "group query failed: " + std::to_string((int)ev->result)
+                    : "no shared frame published to this group yet");
+                break;
+            }
             if (XR_FAILED(ev->result)) {
                 ALOGW("space query completed with error: %d", (int)ev->result);
             }
@@ -504,12 +530,101 @@ void VROARSessionOpenXR::onSpatialEvent(const XrEventDataBuffer &event) {
             break;
         }
         case XR_TYPE_EVENT_DATA_SPACE_SET_STATUS_COMPLETE_FB: {
+            auto *ev = reinterpret_cast<const XrEventDataSpaceSetStatusCompleteFB *>(&event);
+
+            // Shared-frame path owns this event while an operation is running on
+            // the space it names; the scene path re-arms for everything else.
+            if (_sharedFrame.phase == SharedFrameOp::Phase::EnablingComponents &&
+                ev->space == _sharedFrame.space) {
+                if (XR_FAILED(ev->result)) {
+                    finishSharedFrame(false, "enabling anchor component failed: " +
+                                              std::to_string((int)ev->result));
+                    break;
+                }
+                if (--_sharedFrame.pendingComponents > 0) break;
+
+                if (_sharedFrame.joining) {
+                    locateAndReportSharedFrame();
+                } else {
+                    XrShareSpacesRecipientGroupsMETA recipients{
+                        (XrStructureType)XR_TYPE_SHARE_SPACES_RECIPIENT_GROUPS_META };
+                    recipients.groupCount = 1;
+                    recipients.groups     = &_sharedFrame.groupUuid;
+
+                    XrShareSpacesInfoMETA share{
+                        (XrStructureType)XR_TYPE_SHARE_SPACES_INFO_META };
+                    share.spaceCount    = 1;
+                    share.spaces        = &_sharedFrame.space;
+                    share.recipientInfo =
+                        reinterpret_cast<const XrShareSpacesRecipientBaseHeaderMETA *>(&recipients);
+
+                    XrAsyncRequestIdFB requestId = 0;
+                    XrResult r = _pfnShareSpaces(_session, &share, &requestId);
+                    if (XR_FAILED(r)) {
+                        finishSharedFrame(false, "xrShareSpacesMETA failed: " +
+                                                  std::to_string((int)r));
+                        break;
+                    }
+                    _sharedFrame.requestId = requestId;
+                    _sharedFrame.phase     = SharedFrameOp::Phase::Sharing;
+                }
+                break;
+            }
+
             // A component (LOCATABLE) finished enabling — re-query promptly so the
             // now-locatable plane gets built without waiting the full cadence.
-            auto *ev = reinterpret_cast<const XrEventDataSpaceSetStatusCompleteFB *>(&event);
             if (!XR_FAILED(ev->result) && !_sceneQueryInFlight) {
                 _lastSceneQuery = std::chrono::steady_clock::time_point{};  // re-arm next frame
             }
+            break;
+        }
+
+        case XR_TYPE_EVENT_DATA_SPATIAL_ANCHOR_CREATE_COMPLETE_FB: {
+            auto *ev = reinterpret_cast<const XrEventDataSpatialAnchorCreateCompleteFB *>(&event);
+            if (_sharedFrame.phase != SharedFrameOp::Phase::Creating ||
+                ev->requestId != _sharedFrame.requestId) break;
+
+            if (XR_FAILED(ev->result)) {
+                finishSharedFrame(false, "anchor creation failed: " +
+                                          std::to_string((int)ev->result));
+                break;
+            }
+
+            _sharedFrame.space     = ev->space;
+            _sharedFrame.spaceUuid = ev->uuid;
+            _sharedFrame.phase     = SharedFrameOp::Phase::EnablingComponents;
+
+            // STORABLE before SHARABLE: an anchor that is not saved locally has
+            // nothing to hand over. Each returns true only when it will actually
+            // raise a completion event, so already-enabled does not hang the count.
+            int pending = 0;
+            if (enableSharedFrameComponent(ev->space, XR_SPACE_COMPONENT_TYPE_STORABLE_FB)) pending++;
+            if (enableSharedFrameComponent(ev->space, XR_SPACE_COMPONENT_TYPE_SHARABLE_FB)) pending++;
+            _sharedFrame.pendingComponents = pending;
+
+            // Nothing to wait for — both were already enabled.
+            if (pending == 0) {
+                _sharedFrame.pendingComponents = 1;
+                XrEventDataSpaceSetStatusCompleteFB synthetic{
+                    XR_TYPE_EVENT_DATA_SPACE_SET_STATUS_COMPLETE_FB };
+                synthetic.result = XR_SUCCESS;
+                synthetic.space  = ev->space;
+                onSpatialEvent(*reinterpret_cast<const XrEventDataBuffer *>(&synthetic));
+            }
+            break;
+        }
+
+        case XR_TYPE_EVENT_DATA_SHARE_SPACES_COMPLETE_META: {
+            auto *ev = reinterpret_cast<const XrEventDataShareSpacesCompleteMETA *>(&event);
+            if (_sharedFrame.phase != SharedFrameOp::Phase::Sharing ||
+                ev->requestId != _sharedFrame.requestId) break;
+
+            if (XR_FAILED(ev->result)) {
+                finishSharedFrame(false, "sharing the frame failed: " +
+                                          std::to_string((int)ev->result));
+                break;
+            }
+            locateAndReportSharedFrame();
             break;
         }
         default:

--- a/android/sharedCode/src/main/cpp/VROARSessionOpenXR.h
+++ b/android/sharedCode/src/main/cpp/VROARSessionOpenXR.h
@@ -71,6 +71,15 @@ public:
     /* Forward FB spatial-query events (polled by the renderer's xrPollEvent loop). */
     void onSpatialEvent(const XrEventDataBuffer &event);
 
+    // ── Shared coordinate frame (CL-H) ─────────────────────────────────────────
+    bool rvSupportsSharedFrame() override;
+    void rvCreateSharedFrame(
+        std::string groupId,
+        std::function<void(bool, std::string, std::string, std::string)> callback) override;
+    void rvJoinSharedFrame(
+        std::string groupId,
+        std::function<void(bool, std::string, std::string, std::string)> callback) override;
+
     /* Tear down detectors. Call from the renderer's destroySession(). */
     void destroyPlaneDetector();
 
@@ -154,6 +163,42 @@ private:
     std::map<uint64_t, std::shared_ptr<VROARPlaneAnchor>> _scenePlanes; // FB path (XrSpace handle)
 
     std::unique_ptr<VROARFrame> _currentFrame;
+
+    // ── Shared frame: XR_FB_spatial_entity + XR_META_spatial_entity_group_sharing
+    //
+    // Group sharing rather than XR_FB_spatial_entity_sharing on purpose: the FB
+    // path shares to XrSpaceUserFB handles built from Meta account ids, which
+    // only the Meta Platform SDK can supply and which this repo does not carry.
+    // Group sharing keys off an app-chosen UUID instead, so the whole flow stays
+    // inside OpenXR — and that UUID doubles as the co-location room key.
+    bool _sharingAvailable = false;
+    PFN_xrCreateSpatialAnchorFB _pfnCreateSpatialAnchor = nullptr;
+    PFN_xrShareSpacesMETA       _pfnShareSpaces         = nullptr;
+
+    using SharedFrameCallback =
+        std::function<void(bool, std::string, std::string, std::string)>;
+
+    // One shared-frame operation at a time. Two in flight would race on the
+    // component-enable events, which carry no correlation back to the request
+    // that asked for them — only the XrSpace they apply to.
+    struct SharedFrameOp {
+        enum class Phase { Idle, Creating, EnablingComponents, Sharing, Querying, Locating };
+        Phase             phase = Phase::Idle;
+        bool              joining = false;      // join vs create
+        XrUuid            groupUuid{};
+        XrSpace           space = XR_NULL_HANDLE;
+        XrUuidEXT         spaceUuid{};
+        XrAsyncRequestIdFB requestId = 0;
+        int               pendingComponents = 0;
+        SharedFrameCallback callback;
+    };
+    SharedFrameOp _sharedFrame;
+
+    void finishSharedFrame(bool success, const std::string &error);
+    bool enableSharedFrameComponent(XrSpace space, XrSpaceComponentTypeFB component);
+    void locateAndReportSharedFrame();
+    void beginGroupQuery();
+    void processSharedFrameQueryResults(XrAsyncRequestIdFB requestId);
 
     // ── EXT helpers ─────────────────────────────────────────────────────────
     void beginDetectionSweep();

--- a/android/sharedCode/src/main/cpp/VROARSessionOpenXRSharedFrame.cpp
+++ b/android/sharedCode/src/main/cpp/VROARSessionOpenXRSharedFrame.cpp
@@ -1,0 +1,298 @@
+//
+//  VROARSessionOpenXRSharedFrame.cpp
+//  ViroRenderer
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+//  Platform-native co-location for Quest (CL-H).
+//
+//  Quest cannot relocalise a ReactVision cloud anchor — the OpenXR session
+//  produces no camera image for the SIFT localiser — but it does not need to.
+//  Meta's spatial anchors already solve co-location, sensor-fused, and this
+//  drives them through OpenXR alone:
+//
+//    create  xrCreateSpatialAnchorFB → enable STORABLE + SHARABLE
+//            → xrShareSpacesMETA to a group UUID
+//    join    xrQuerySpacesFB filtered by that group UUID
+//            → enable LOCATABLE → xrLocateSpace
+//
+//  Group sharing (XR_META_spatial_entity_group_sharing) rather than
+//  XR_FB_spatial_entity_sharing: the FB path addresses recipients as
+//  XrSpaceUserFB handles built from Meta account ids, which only the Meta
+//  Platform SDK can supply. Group sharing takes an app-chosen UUID, so the flow
+//  stays inside OpenXR — and that UUID is also the co-location room key, which
+//  means one identifier names the space, the frame and the channel room.
+//
+//  Everything here is asynchronous through the renderer's xrPollEvent loop; see
+//  onSpatialEvent() in VROARSessionOpenXR.cpp for the dispatch.
+//
+
+#include "VROARSessionOpenXR.h"
+#include "VROLog.h"
+
+#include <android/log.h>
+#define LOG_TAG "ViroSharedFrame"
+#define ALOGW(...) __android_log_print(ANDROID_LOG_WARN,    LOG_TAG, __VA_ARGS__)
+#define ALOGV(...) __android_log_print(ANDROID_LOG_VERBOSE, LOG_TAG, __VA_ARGS__)
+#include "VROMatrix4f.h"
+#include "VROVector3f.h"
+#include "VROQuaternion.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// ============================================================================
+// UUID <-> string
+// ============================================================================
+
+namespace {
+
+/** Canonical 8-4-4-4-12 hex. Returns false on anything else. */
+bool parseUuid(const std::string &str, XrUuid *out) {
+    if (!out) return false;
+    std::memset(out, 0, sizeof(XrUuid));
+
+    // Accept with or without hyphens; anything else is a caller error.
+    std::string hex;
+    hex.reserve(32);
+    for (char c : str) {
+        if (c == '-') continue;
+        if (!isxdigit((unsigned char)c)) return false;
+        hex += c;
+    }
+    if (hex.size() != 32) return false;
+
+    for (int i = 0; i < 16; i++) {
+        unsigned int byte = 0;
+        if (sscanf(hex.c_str() + i * 2, "%2x", &byte) != 1) return false;
+        out->data[i] = (uint8_t)byte;
+    }
+    return true;
+}
+
+std::string formatUuid(const XrUuid &uuid) {
+    char buf[37];
+    snprintf(buf, sizeof(buf),
+             "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+             uuid.data[0],  uuid.data[1],  uuid.data[2],  uuid.data[3],
+             uuid.data[4],  uuid.data[5],  uuid.data[6],  uuid.data[7],
+             uuid.data[8],  uuid.data[9],  uuid.data[10], uuid.data[11],
+             uuid.data[12], uuid.data[13], uuid.data[14], uuid.data[15]);
+    return std::string(buf);
+}
+
+/** Same encoding resolveCloudAnchor() emits, so JS treats both identically. */
+std::string matrixToCsv(const VROMatrix4f &m) {
+    const float *a = m.getArray();
+    std::string csv;
+    char buf[32];
+    for (int i = 0; i < 16; ++i) {
+        snprintf(buf, sizeof(buf), i == 0 ? "%g" : ",%g", a[i]);
+        csv += buf;
+    }
+    return csv;
+}
+
+VROMatrix4f poseToMatrix(const XrPosef &pose) {
+    VROQuaternion q(pose.orientation.x, pose.orientation.y,
+                    pose.orientation.z, pose.orientation.w);
+    VROMatrix4f m = q.getMatrix();
+    m.translate({ pose.position.x, pose.position.y, pose.position.z });
+    return m;
+}
+
+} // namespace
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+bool VROARSessionOpenXR::rvSupportsSharedFrame() {
+    return _sharingAvailable && _pfnCreateSpatialAnchor && _pfnShareSpaces &&
+           _pfnQuerySpaces && _pfnSetSpaceComponentStatus;
+}
+
+void VROARSessionOpenXR::rvCreateSharedFrame(
+        std::string groupId,
+        std::function<void(bool, std::string, std::string, std::string)> callback) {
+
+    if (!rvSupportsSharedFrame()) {
+        if (callback) callback(false, "", "",
+            "Shared frames unavailable: XR_META_spatial_entity_group_sharing not present");
+        return;
+    }
+    if (_sharedFrame.phase != SharedFrameOp::Phase::Idle) {
+        if (callback) callback(false, "", "", "A shared-frame operation is already running");
+        return;
+    }
+
+    XrUuid group{};
+    if (!parseUuid(groupId, &group)) {
+        if (callback) callback(false, "", "", "groupId must be a UUID");
+        return;
+    }
+
+    _sharedFrame = SharedFrameOp{};
+    _sharedFrame.joining   = false;
+    _sharedFrame.groupUuid = group;
+    _sharedFrame.callback  = std::move(callback);
+    _sharedFrame.phase     = SharedFrameOp::Phase::Creating;
+
+    // Anchor at the app's reference-space origin rather than at the head pose:
+    // the frame should not depend on where the user happened to be standing when
+    // they tapped, and every device joining it gets the same origin regardless.
+    XrSpatialAnchorCreateInfoFB info{ XR_TYPE_SPATIAL_ANCHOR_CREATE_INFO_FB };
+    info.space              = _baseSpace;
+    info.poseInSpace.orientation = { 0, 0, 0, 1 };
+    info.poseInSpace.position    = { 0, 0, 0 };
+    info.time               = _displayTime;
+
+    XrAsyncRequestIdFB requestId = 0;
+    XrResult r = _pfnCreateSpatialAnchor(_session, &info, &requestId);
+    if (XR_FAILED(r)) {
+        finishSharedFrame(false, "xrCreateSpatialAnchorFB failed: " + std::to_string((int)r));
+        return;
+    }
+    _sharedFrame.requestId = requestId;
+}
+
+void VROARSessionOpenXR::rvJoinSharedFrame(
+        std::string groupId,
+        std::function<void(bool, std::string, std::string, std::string)> callback) {
+
+    if (!rvSupportsSharedFrame()) {
+        if (callback) callback(false, "", "",
+            "Shared frames unavailable: XR_META_spatial_entity_group_sharing not present");
+        return;
+    }
+    if (_sharedFrame.phase != SharedFrameOp::Phase::Idle) {
+        if (callback) callback(false, "", "", "A shared-frame operation is already running");
+        return;
+    }
+
+    XrUuid group{};
+    if (!parseUuid(groupId, &group)) {
+        if (callback) callback(false, "", "", "groupId must be a UUID");
+        return;
+    }
+
+    _sharedFrame = SharedFrameOp{};
+    _sharedFrame.joining   = true;
+    _sharedFrame.groupUuid = group;
+    _sharedFrame.callback  = std::move(callback);
+
+    beginGroupQuery();
+}
+
+// ============================================================================
+// Internals
+// ============================================================================
+
+void VROARSessionOpenXR::beginGroupQuery() {
+    // The group filter chains onto the standard query the scene path already
+    // uses; only the filter differs.
+    XrSpaceGroupUuidFilterInfoMETA groupFilter{
+        (XrStructureType)XR_TYPE_SPACE_GROUP_UUID_FILTER_INFO_META };
+    groupFilter.groupUuid = _sharedFrame.groupUuid;
+
+    XrSpaceQueryInfoFB query{ XR_TYPE_SPACE_QUERY_INFO_FB };
+    query.queryAction  = XR_SPACE_QUERY_ACTION_LOAD_FB;
+    query.maxResultCount = 16;
+    query.timeout      = 0;
+    query.filter       = reinterpret_cast<const XrSpaceFilterInfoBaseHeaderFB *>(&groupFilter);
+    query.excludeFilter = nullptr;
+
+    XrAsyncRequestIdFB requestId = 0;
+    XrResult r = _pfnQuerySpaces(
+        _session, reinterpret_cast<const XrSpaceQueryInfoBaseHeaderFB *>(&query), &requestId);
+    if (XR_FAILED(r)) {
+        finishSharedFrame(false, "xrQuerySpacesFB failed: " + std::to_string((int)r));
+        return;
+    }
+    _sharedFrame.requestId = requestId;
+    _sharedFrame.phase     = SharedFrameOp::Phase::Querying;
+}
+
+bool VROARSessionOpenXR::enableSharedFrameComponent(XrSpace space,
+                                                    XrSpaceComponentTypeFB component) {
+    XrSpaceComponentStatusSetInfoFB set{ XR_TYPE_SPACE_COMPONENT_STATUS_SET_INFO_FB };
+    set.componentType = component;
+    set.enabled       = XR_TRUE;
+    set.timeout       = 0;
+
+    XrAsyncRequestIdFB requestId = 0;
+    XrResult r = _pfnSetSpaceComponentStatus(space, &set, &requestId);
+
+    // Already enabled is a success, not a failure — a rejoined anchor arrives
+    // with components the previous session turned on.
+    if (r == XR_ERROR_SPACE_COMPONENT_STATUS_ALREADY_SET_FB) return false;
+    if (XR_FAILED(r)) {
+        ALOGW("[shared-frame] enable component %d failed: %d", (int)component, (int)r);
+        return false;
+    }
+    return true;   // async: expect a SET_STATUS_COMPLETE event
+}
+
+void VROARSessionOpenXR::locateAndReportSharedFrame() {
+    XrSpaceLocation loc{ XR_TYPE_SPACE_LOCATION };
+    XrResult r = xrLocateSpace(_sharedFrame.space, _baseSpace, _displayTime, &loc);
+
+    const XrSpaceLocationFlags needed =
+        XR_SPACE_LOCATION_POSITION_VALID_BIT | XR_SPACE_LOCATION_ORIENTATION_VALID_BIT;
+
+    if (XR_FAILED(r) || (loc.locationFlags & needed) != needed) {
+        // Not an error worth failing on immediately — tracking may simply not
+        // have caught up with a just-loaded anchor. The caller retries.
+        finishSharedFrame(false, "shared frame is not locatable yet");
+        return;
+    }
+
+    std::string csv = matrixToCsv(poseToMatrix(loc.pose));
+    std::string frameId = formatUuid(_sharedFrame.spaceUuid);
+
+    SharedFrameCallback cb = std::move(_sharedFrame.callback);
+    _sharedFrame = SharedFrameOp{};
+    if (cb) cb(true, frameId, csv, "");
+}
+
+void VROARSessionOpenXR::finishSharedFrame(bool success, const std::string &error) {
+    SharedFrameCallback cb = std::move(_sharedFrame.callback);
+    std::string frameId = success ? formatUuid(_sharedFrame.spaceUuid) : "";
+    _sharedFrame = SharedFrameOp{};
+    if (cb) cb(success, frameId, "", error);
+}
+
+void VROARSessionOpenXR::processSharedFrameQueryResults(XrAsyncRequestIdFB requestId) {
+    XrSpaceQueryResultsFB results{ XR_TYPE_SPACE_QUERY_RESULTS_FB };
+    if (XR_FAILED(_pfnRetrieveSpaceQueryResults(_session, requestId, &results))) {
+        finishSharedFrame(false, "retrieving group query results failed");
+        return;
+    }
+
+    std::vector<XrSpaceQueryResultFB> buffer(results.resultCountOutput);
+    results.resultCapacityInput = (uint32_t)buffer.size();
+    results.results             = buffer.data();
+
+    if (buffer.empty() ||
+        XR_FAILED(_pfnRetrieveSpaceQueryResults(_session, requestId, &results))) {
+        finishSharedFrame(false, "no shared frame published to this group yet");
+        return;
+    }
+
+    // A group holds one frame by construction — the first device to publish
+    // defines it. Extra results would mean two devices raced; taking the first
+    // keeps every joiner on the same one rather than picking arbitrarily.
+    _sharedFrame.space     = buffer[0].space;
+    _sharedFrame.spaceUuid = buffer[0].uuid;
+    _sharedFrame.phase     = SharedFrameOp::Phase::EnablingComponents;
+
+    int pending = 0;
+    if (enableSharedFrameComponent(buffer[0].space, XR_SPACE_COMPONENT_TYPE_LOCATABLE_FB)) {
+        pending++;
+    }
+    _sharedFrame.pendingComponents = pending;
+
+    // Already locatable — a rejoin within the same session takes this path.
+    if (pending == 0) locateAndReportSharedFrame();
+}

--- a/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
+++ b/android/sharedCode/src/main/cpp/arcore/ARSceneController_JNI.cpp
@@ -742,6 +742,72 @@ VRO_METHOD(void, nativeRvFinishScan)(VRO_ARGS
     });
 }
 
+// Shared coordinate frames (CL-H). The result shape matches finishScan's
+// exactly — success, an id, a transform CSV, an error — so the same Java
+// callback and the same JS plumbing carry both, and a frame source does not
+// care which produced it.
+static void rvFireSharedFrameResult(VRO_WEAK weakObj, std::string keyStr,
+                                     bool success, std::string frameId,
+                                     std::string transformCsv, std::string error) {
+    VROPlatformDispatchAsyncApplication([weakObj, keyStr, success, frameId, transformCsv, error] {
+        VRO_ENV env = VROPlatformGetJNIEnv();
+        VRO_OBJECT localObj = VRO_NEW_LOCAL_REF(weakObj);
+        if (VRO_IS_OBJECT_NULL(localObj)) {
+            VRO_DELETE_LOCAL_REF(localObj);
+            VRO_DELETE_WEAK_GLOBAL_REF(weakObj);
+            return;
+        }
+        VRO_STRING jKey = VRO_NEW_STRING(keyStr.c_str());
+        VRO_STRING jId  = VRO_NEW_STRING(frameId.c_str());
+        VRO_STRING jCsv = VRO_NEW_STRING(transformCsv.c_str());
+        VRO_STRING jErr = VRO_NEW_STRING(error.c_str());
+        VROPlatformCallHostFunction(localObj, "onRvSharedFrameResult",
+            "(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;)V",
+            jKey, (jboolean)success, jId, jCsv, jErr);
+        VRO_DELETE_LOCAL_REF(localObj);
+        VRO_DELETE_WEAK_GLOBAL_REF(weakObj);
+    });
+}
+
+// `joining` picks create vs join rather than two near-identical natives: the
+// dispatch, session lookup and failure path are the whole body otherwise.
+static void rvSharedFrameOp(VRO_ENV env, VRO_OBJECT obj,
+                             VRO_REF(VROARSceneController) arSceneControllerPtr,
+                             jstring key_j, jstring groupId_j, bool joining) {
+    std::string keyStr   = VRO_STRING_STL(key_j);
+    std::string groupStr = VRO_STRING_STL(groupId_j);
+    std::weak_ptr<VROARScene> arScene_w = std::dynamic_pointer_cast<VROARScene>(
+        VRO_REF_GET(VROARSceneController, arSceneControllerPtr)->getScene());
+    VRO_WEAK weakObj = VRO_NEW_WEAK_GLOBAL_REF(obj);
+
+    VROPlatformDispatchAsyncRenderer([arScene_w, weakObj, keyStr, groupStr, joining] {
+        std::shared_ptr<VROARScene> arScene = arScene_w.lock();
+        std::shared_ptr<VROARSession> arSession = arScene ? arScene->getARSession() : nullptr;
+        if (!arSession) {
+            rvFireSharedFrameResult(weakObj, keyStr, false, "", "", "AR session not available");
+            return;
+        }
+        auto cb = [weakObj, keyStr](bool success, std::string frameId,
+                                     std::string csv, std::string error) {
+            rvFireSharedFrameResult(weakObj, keyStr, success, frameId, csv, error);
+        };
+        if (joining) arSession->rvJoinSharedFrame(groupStr, cb);
+        else         arSession->rvCreateSharedFrame(groupStr, cb);
+    });
+}
+
+VRO_METHOD(void, nativeRvCreateSharedFrame)(VRO_ARGS
+                                            VRO_REF(VROARSceneController) arSceneControllerPtr,
+                                            jstring key_j, jstring groupId_j) {
+    rvSharedFrameOp(env, obj, arSceneControllerPtr, key_j, groupId_j, false);
+}
+
+VRO_METHOD(void, nativeRvJoinSharedFrame)(VRO_ARGS
+                                          VRO_REF(VROARSceneController) arSceneControllerPtr,
+                                          jstring key_j, jstring groupId_j) {
+    rvSharedFrameOp(env, obj, arSceneControllerPtr, key_j, groupId_j, true);
+}
+
 VRO_METHOD(void, nativeRvGetCloudAnchor)(VRO_ARGS
                                          VRO_REF(VROARSceneController) arSceneControllerPtr,
                                          jstring key_j, jstring anchorId_j) {

--- a/android/sharedCode/src/main/java/com/viro/core/ARScene.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ARScene.java
@@ -1502,6 +1502,43 @@ public class ARScene extends Scene {
     }
 
     /**
+     * CL-H: result of establishing a platform-native shared coordinate frame.
+     * Same shape as {@link RvFinishScanCallback} on purpose — a shared frame and
+     * a hosted scan are interchangeable to everything downstream.
+     */
+    public interface RvSharedFrameCallback {
+        void onResult(boolean success, String frameId, String transformCsv, String error);
+    }
+
+    private Map<String, RvSharedFrameCallback> mRvSharedFrameCallbacks = new HashMap<>();
+
+    void onRvSharedFrameResult(String key, boolean success, String frameId,
+                                String transformCsv, String error) {
+        RvSharedFrameCallback cb = mRvSharedFrameCallbacks.remove(key);
+        if (cb != null) cb.onResult(success, frameId, transformCsv, error);
+    }
+
+    /**
+     * CL-H: establish a shared coordinate frame and publish it to {@code groupId}
+     * for other devices to join. Quest only; other platforms report unsupported
+     * through the callback.
+     *
+     * @param groupId a UUID chosen by the app. Also the co-location room key.
+     */
+    public void rvCreateSharedFrame(String groupId, RvSharedFrameCallback callback) {
+        String key = "rvCreateSharedFrame_" + System.nanoTime();
+        mRvSharedFrameCallbacks.put(key, callback);
+        nativeRvCreateSharedFrame(mNativeRef, key, groupId);
+    }
+
+    /** CL-H: recover a frame another device published to {@code groupId}. */
+    public void rvJoinSharedFrame(String groupId, RvSharedFrameCallback callback) {
+        String key = "rvJoinSharedFrame_" + System.nanoTime();
+        mRvSharedFrameCallbacks.put(key, callback);
+        nativeRvJoinSharedFrame(mNativeRef, key, groupId);
+    }
+
+    /**
      * WS-A: begin a room/building-scale scan with its own self-defined location
      * frame, independent of any placed anchor. Resets the native background
      * keyframe buffer. Call {@link #rvFinishScan} when done scanning.
@@ -1913,6 +1950,8 @@ public class ARScene extends Scene {
     // Cloud anchor management native methods
     private native void nativeRvStartScan(long sceneControllerRef);
     private native void nativeRvFinishScan(long sceneControllerRef, String key, int ttlDays);
+    private native void nativeRvCreateSharedFrame(long sceneControllerRef, String key, String groupId);
+    private native void nativeRvJoinSharedFrame(long sceneControllerRef, String key, String groupId);
     private native void nativeRvGetCloudAnchor(long sceneControllerRef, String key, String anchorId);
     private native void nativeRvListCloudAnchors(long sceneControllerRef, String key,
                                                   int limit, int offset);

--- a/android/sharedCode/src/main/java/com/viro/core/ColocationSession.java
+++ b/android/sharedCode/src/main/java/com/viro/core/ColocationSession.java
@@ -1,0 +1,143 @@
+// Copyright © 2026 ReactVision. All rights reserved.
+//
+// Java surface for the co-location frame channel.
+//
+// Deliberately a plain class and not part of ARScene: the channel needs no AR
+// session, only a room id and poses, so binding it to one would put it out of
+// reach on the platforms that have no ARScene.
+//
+// One session per process — a device is in one room at a time, and joining
+// again is a switch, not a second membership.
+
+package com.viro.core;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ColocationSession {
+
+    /** One peer's last known pose, in the shared location frame. */
+    public static class Peer {
+        public final String peerId;
+        /** Location-frame position. Never world coordinates. */
+        public final float[] position;   // x, y, z
+        public final float[] rotation;   // quaternion x, y, z, w
+        public final double timestampMs;
+        public final boolean localized;
+
+        Peer(String peerId, float[] position, float[] rotation,
+             double timestampMs, boolean localized) {
+            this.peerId = peerId;
+            this.position = position;
+            this.rotation = rotation;
+            this.timestampMs = timestampMs;
+            this.localized = localized;
+        }
+    }
+
+    public static final int STATE_IDLE         = 0;
+    public static final int STATE_JOINING      = 1;
+    public static final int STATE_JOINED       = 2;
+    public static final int STATE_RECONNECTING = 3;
+    public static final int STATE_FAILED       = 4;
+
+    public interface JoinCallback {
+        void onResult(boolean success, String error);
+    }
+
+    private static ColocationSession sInstance;
+
+    public static synchronized ColocationSession getInstance() {
+        if (sInstance == null) sInstance = new ColocationSession();
+        return sInstance;
+    }
+
+    private final Map<String, JoinCallback> mJoinCallbacks = new HashMap<>();
+
+    private ColocationSession() {}
+
+    /** False when ReactVisionCCA is not linked or the platform has no socket. */
+    public boolean isAvailable() {
+        return nativeIsAvailable();
+    }
+
+    /**
+     * Join the room named by {@code roomId} — the cloud anchor id, Meta group
+     * id or visionOS session id that already names the shared frame.
+     */
+    public void join(String roomId, String apiKey, String projectId,
+                     String endpoint, JoinCallback callback) {
+        String key = "colocationJoin_" + System.nanoTime();
+        mJoinCallbacks.put(key, callback);
+        nativeJoin(key, roomId, apiKey, projectId, endpoint == null ? "" : endpoint);
+    }
+
+    public void leave() {
+        nativeLeave();
+    }
+
+    /**
+     * Publish the local pose as 16 comma-separated floats, column-major, **in
+     * the shared location frame**. World coordinates are per-session and mean
+     * nothing to the receiver.
+     */
+    public void setLocalPose(String locationFramePoseCsv) {
+        if (locationFramePoseCsv == null) return;
+        nativeSetLocalPose(locationFramePoseCsv);
+    }
+
+    public int getState() {
+        return nativeGetState();
+    }
+
+    public String getLocalPeerId() {
+        return nativeGetLocalPeerId();
+    }
+
+    /**
+     * Current peers, excluding this device.
+     *
+     * Native returns one flat string rather than an object array: this is
+     * polled several times a second, and building an array across JNI costs a
+     * local ref per field for no benefit.
+     */
+    public List<Peer> getPeers() {
+        List<Peer> out = new ArrayList<>();
+        String raw = nativeGetPeers();
+        if (raw == null || raw.isEmpty()) return out;
+
+        for (String row : raw.split(";")) {
+            String[] f = row.split(",");
+            if (f.length != 10) continue;   // a malformed row is dropped, not fatal
+            try {
+                out.add(new Peer(
+                        f[0],
+                        new float[]{ Float.parseFloat(f[1]), Float.parseFloat(f[2]), Float.parseFloat(f[3]) },
+                        new float[]{ Float.parseFloat(f[4]), Float.parseFloat(f[5]),
+                                     Float.parseFloat(f[6]), Float.parseFloat(f[7]) },
+                        Double.parseDouble(f[8]),
+                        "1".equals(f[9])));
+            } catch (NumberFormatException ignored) {
+                // Same: skip the row rather than lose the whole poll.
+            }
+        }
+        return out;
+    }
+
+    // Called from JNI.
+    void onJoinResult(String key, boolean success, String error) {
+        JoinCallback cb = mJoinCallbacks.remove(key);
+        if (cb != null) cb.onResult(success, error);
+    }
+
+    private native boolean nativeIsAvailable();
+    private native void    nativeJoin(String key, String roomId, String apiKey,
+                                      String projectId, String endpoint);
+    private native void    nativeLeave();
+    private native void    nativeSetLocalPose(String csv);
+    private native int     nativeGetState();
+    private native String  nativeGetLocalPeerId();
+    private native String  nativeGetPeers();
+}

--- a/ios/ViroKit/VROColocationBridge.h
+++ b/ios/ViroKit/VROColocationBridge.h
@@ -1,0 +1,71 @@
+//
+//  VROColocationBridge.h
+//  ViroKit
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+//  Objective-C surface for the co-location frame channel, for iOS and visionOS.
+//
+//  Pure Objective-C on purpose. visionOS narrows what it can import to headers
+//  that parse as plain Objective-C — most of this framework reaches into the
+//  renderer's C++ — and the channel is one of the few things that has to work
+//  on a platform where the AR subsystem does not exist at all.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/** One peer's last known pose, in the shared location frame. */
+@interface VROColocationPeerInfo : NSObject
+@property (nonatomic, copy)   NSString *peerId;
+/** Location-frame position [x, y, z]. Never world coordinates. */
+@property (nonatomic, copy)   NSArray<NSNumber *> *position;
+/** Quaternion [x, y, z, w]. */
+@property (nonatomic, copy)   NSArray<NSNumber *> *rotation;
+@property (nonatomic, assign) double timestampMs;
+@property (nonatomic, assign) BOOL localized;
+@end
+
+typedef NS_ENUM(NSInteger, VROColocationBridgeState) {
+    VROColocationBridgeStateIdle         = 0,
+    VROColocationBridgeStateJoining      = 1,
+    VROColocationBridgeStateJoined       = 2,
+    VROColocationBridgeStateReconnecting = 3,
+    VROColocationBridgeStateFailed       = 4,
+};
+
+@interface VROColocationBridge : NSObject
+
+/** One session per process: a device is in one room at a time. */
++ (instancetype)shared;
+
+/** NO when ReactVisionCCA is not linked, or the platform has no socket. */
+- (BOOL)isAvailable;
+
+/**
+ * Join the room named by `roomId` — the cloud anchor id, Meta group id or
+ * visionOS session id that already names the shared frame. Leaves any current
+ * room. Pass nil for `endpoint` to use the default.
+ */
+- (void)joinRoom:(NSString *)roomId
+          apiKey:(NSString *)apiKey
+       projectId:(NSString *)projectId
+        endpoint:(nullable NSString *)endpoint
+      completion:(void (^)(BOOL success, NSString *error))completion;
+
+- (void)leave;
+
+/**
+ * Publish the local pose as 16 comma-separated floats, column-major, **in the
+ * shared location frame**. Safe to call every frame.
+ */
+- (void)setLocalPoseCsv:(NSString *)csv;
+
+- (VROColocationBridgeState)state;
+- (NSString *)localPeerId;
+- (NSArray<VROColocationPeerInfo *> *)peers;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/ViroKit/VROColocationBridge.mm
+++ b/ios/ViroKit/VROColocationBridge.mm
@@ -1,0 +1,103 @@
+//
+//  VROColocationBridge.mm
+//  ViroKit
+//
+//  Copyright © 2026 ReactVision. All rights reserved.
+//
+
+#import "VROColocationBridge.h"
+#include "VROColocationSession.h"
+#include "VROMatrix4f.h"
+
+#include <string>
+
+@implementation VROColocationPeerInfo
+@end
+
+namespace {
+
+/** 16 comma-separated floats, column-major — the encoding every layer uses. */
+bool parseMatrixCsv(NSString *csv, VROMatrix4f *out) {
+    if (csv == nil) return false;
+    NSArray<NSString *> *parts = [csv componentsSeparatedByString:@","];
+    if (parts.count != 16) return false;
+
+    float v[16];
+    for (NSUInteger i = 0; i < 16; i++) {
+        v[i] = parts[i].floatValue;
+        if (isnan(v[i])) return false;
+    }
+    *out = VROMatrix4f(v);
+    return true;
+}
+
+} // namespace
+
+@implementation VROColocationBridge
+
++ (instancetype)shared {
+    static VROColocationBridge *instance = nil;
+    static dispatch_once_t once;
+    dispatch_once(&once, ^{ instance = [[VROColocationBridge alloc] init]; });
+    return instance;
+}
+
+- (BOOL)isAvailable {
+    return VROColocationSession::get().isAvailable() ? YES : NO;
+}
+
+- (void)joinRoom:(NSString *)roomId
+          apiKey:(NSString *)apiKey
+       projectId:(NSString *)projectId
+        endpoint:(NSString *)endpoint
+      completion:(void (^)(BOOL, NSString *))completion {
+
+    VROColocationSession::get().join(
+        std::string(roomId.UTF8String    ?: ""),
+        std::string(apiKey.UTF8String    ?: ""),
+        std::string(projectId.UTF8String ?: ""),
+        std::string(endpoint.UTF8String  ?: ""),
+        [completion](bool success, std::string error) {
+            if (!completion) return;
+            NSString *err = [NSString stringWithUTF8String:error.c_str()] ?: @"";
+            // Callbacks arrive on the socket thread; JS-facing work belongs on
+            // the main queue, and every caller here is a React Native module.
+            dispatch_async(dispatch_get_main_queue(), ^{ completion(success, err); });
+        });
+}
+
+- (void)leave {
+    VROColocationSession::get().leave();
+}
+
+- (void)setLocalPoseCsv:(NSString *)csv {
+    VROMatrix4f m;
+    if (!parseMatrixCsv(csv, &m)) return;
+    VROColocationSession::get().setLocalPose(m);
+}
+
+- (VROColocationBridgeState)state {
+    return (VROColocationBridgeState)VROColocationSession::get().state();
+}
+
+- (NSString *)localPeerId {
+    return [NSString stringWithUTF8String:
+            VROColocationSession::get().localPeerId().c_str()] ?: @"";
+}
+
+- (NSArray<VROColocationPeerInfo *> *)peers {
+    NSMutableArray<VROColocationPeerInfo *> *out = [NSMutableArray array];
+    for (const auto &p : VROColocationSession::get().peers()) {
+        VROColocationPeerInfo *info = [[VROColocationPeerInfo alloc] init];
+        info.peerId      = [NSString stringWithUTF8String:p.peerId.c_str()] ?: @"";
+        info.position    = @[ @(p.position[0]), @(p.position[1]), @(p.position[2]) ];
+        info.rotation    = @[ @(p.rotation[0]), @(p.rotation[1]),
+                              @(p.rotation[2]), @(p.rotation[3]) ];
+        info.timestampMs = p.timestampMs;
+        info.localized   = p.localized ? YES : NO;
+        [out addObject:info];
+    }
+    return out;
+}
+
+@end

--- a/ios/ViroRenderer.xcodeproj/project.pbxproj
+++ b/ios/ViroRenderer.xcodeproj/project.pbxproj
@@ -1154,6 +1154,12 @@
 		E14F91632FFC939E00CA253E /* VROFrontCameraProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = E14F91602FFC939E00CA253E /* VROFrontCameraProvider.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E15075852F185C5700653622 /* VROARHitTestResultiOS.mm in Sources */ = {isa = PBXBuildFile; fileRef = E15075842F185C5700653622 /* VROARHitTestResultiOS.mm */; };
 		E15075862F185C5700653622 /* VROARHitTestResultiOS.h in Headers */ = {isa = PBXBuildFile; fileRef = E15075832F185C5700653622 /* VROARHitTestResultiOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1C010000000000000000004 /* VROColocationBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000001 /* VROColocationBridge.mm */; };
+		E1C010000000000000000005 /* VROColocationSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000003 /* VROColocationSession.cpp */; };
+		E1C010000000000000000006 /* VROColocationBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000000 /* VROColocationBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E1C010000000000000000007 /* VROColocationBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000001 /* VROColocationBridge.mm */; };
+		E1C010000000000000000008 /* VROColocationSession.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000003 /* VROColocationSession.cpp */; };
+		E1C010000000000000000009 /* VROColocationBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = E1C010000000000000000000 /* VROColocationBridge.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E1626A182F46B830005AA731 /* VROCloudAnchorProviderReactVision.h in Headers */ = {isa = PBXBuildFile; fileRef = E1626A162F46B830005AA731 /* VROCloudAnchorProviderReactVision.h */; };
 		E1626A192F46B830005AA731 /* VROCloudAnchorProviderReactVision.mm in Sources */ = {isa = PBXBuildFile; fileRef = E1626A172F46B830005AA731 /* VROCloudAnchorProviderReactVision.mm */; };
 		E1626A1A2F46B83E005AA731 /* VROCloudAnchorProviderReactVision.h in Sources */ = {isa = PBXBuildFile; fileRef = E1626A162F46B830005AA731 /* VROCloudAnchorProviderReactVision.h */; };
@@ -2074,6 +2080,8 @@
 		8FCED0721EBBD35200C19BCA /* SvenArmor_Normal.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = SvenArmor_Normal.png; path = ViroSample/SvenArmor_Normal.png; sourceTree = "<group>"; };
 		8FCED0731EBBD35200C19BCA /* SvenArmor_Spec.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = SvenArmor_Spec.png; path = ViroSample/SvenArmor_Spec.png; sourceTree = "<group>"; };
 		8FCF39621CAEE26F00A86CA3 /* VROHoverDistanceListener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VROHoverDistanceListener.h; sourceTree = "<group>"; };
+		E1C010000000000000000002 /* VROColocationSession.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VROColocationSession.h; sourceTree = "<group>"; };
+		E1C010000000000000000003 /* VROColocationSession.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = VROColocationSession.cpp; sourceTree = "<group>"; };
 		8FCF39691CB4242000A86CA3 /* VRORenderer.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = VRORenderer.cpp; sourceTree = "<group>"; };
 		8FCF396A1CB4242000A86CA3 /* VRORenderer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VRORenderer.h; sourceTree = "<group>"; };
 		8FD06F1C1E831E81003D3BC4 /* VROCameraTexture.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VROCameraTexture.h; sourceTree = "<group>"; };
@@ -2441,6 +2449,8 @@
 		E14F91612FFC939E00CA253E /* VROFrontCameraProvider.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VROFrontCameraProvider.mm; sourceTree = "<group>"; };
 		E15075832F185C5700653622 /* VROARHitTestResultiOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VROARHitTestResultiOS.h; sourceTree = "<group>"; };
 		E15075842F185C5700653622 /* VROARHitTestResultiOS.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VROARHitTestResultiOS.mm; sourceTree = "<group>"; };
+		E1C010000000000000000000 /* VROColocationBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VROColocationBridge.h; sourceTree = "<group>"; };
+		E1C010000000000000000001 /* VROColocationBridge.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VROColocationBridge.mm; sourceTree = "<group>"; };
 		E1626A162F46B830005AA731 /* VROCloudAnchorProviderReactVision.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VROCloudAnchorProviderReactVision.h; sourceTree = "<group>"; };
 		E1626A172F46B830005AA731 /* VROCloudAnchorProviderReactVision.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VROCloudAnchorProviderReactVision.mm; sourceTree = "<group>"; };
 		E188BC742EE37644000A427E /* VROCloudAnchorProviderARCore.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = VROCloudAnchorProviderARCore.mm; sourceTree = "<group>"; };
@@ -2697,6 +2707,8 @@
 				8F65F78C1C90D83600415115 /* VROTransformConstraint.h */,
 				8F65F78B1C90D83600415115 /* VROTransformConstraint.cpp */,
 				8FCF396A1CB4242000A86CA3 /* VRORenderer.h */,
+				E1C010000000000000000002 /* VROColocationSession.h */,
+				E1C010000000000000000003 /* VROColocationSession.cpp */,
 				8FCF39691CB4242000A86CA3 /* VRORenderer.cpp */,
 				8FA81D5E2023EE7100B04790 /* VRORendererConfiguration.h */,
 				8FCB10001DD0055400FE425C /* VRORenderDelegateInternal.h */,
@@ -3581,6 +3593,8 @@
 				8F11B7C41C20B2A20026D150 /* VRORenderDelegate.h */,
 				8FAE504A222C3CD40043220B /* VRODeviceUtil.h */,
 				8FAE504B222C3CD40043220B /* VRODeviceUtil.m */,
+				E1C010000000000000000000 /* VROColocationBridge.h */,
+				E1C010000000000000000001 /* VROColocationBridge.mm */,
 				E1626A162F46B830005AA731 /* VROCloudAnchorProviderReactVision.h */,
 				E1626A172F46B830005AA731 /* VROCloudAnchorProviderReactVision.mm */,
 				8FAE5049222C3CD40043220B /* DeviceList.plist */,
@@ -4090,6 +4104,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1C010000000000000000009 /* VROColocationBridge.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4097,6 +4112,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1C010000000000000000006 /* VROColocationBridge.h in Headers */,
 				E14F91632FFC939E00CA253E /* VROFrontCameraProvider.h in Headers */,
 				8FCA009A22C7DA0E00BB1D70 /* VROVertexBuffer.h in Headers */,
 				A586978A1E308B4500191090 /* VROInputControllerBase.h in Headers */,
@@ -5054,6 +5070,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1C010000000000000000004 /* VROColocationBridge.mm in Sources */,
+				E1C010000000000000000005 /* VROColocationSession.cpp in Sources */,
 				E1BD61882FBBEA93008FDF74 /* VROInputState.h in Sources */,
 				E1BD61892FBBEA95008FDF74 /* VROVirtualControllerRegistry.h in Sources */,
 				E1BD617F2FBBE574008FDF74 /* VRODynamicGeometry.h in Sources */,
@@ -5338,6 +5356,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E1C010000000000000000007 /* VROColocationBridge.mm in Sources */,
+				E1C010000000000000000008 /* VROColocationSession.cpp in Sources */,
 				7C2B122D8273AF546B86E5E6 /* VROAction.cpp in Sources */,
 				DE5CF8FE4DA044BA0C640559 /* VROAllocationTracker.cpp in Sources */,
 				A129455B56737D681EC8B765 /* VROAnimatable.cpp in Sources */,


### PR DESCRIPTION
Part of the co-location workstream. Plan: `plans/viro-colocation-plan.md`. Developer docs: `docs/CO_LOCATION.md`.

Pairs with `viro#feature/co-location` and `rvca#feature/co-location` — the three land together or the JS layer calls symbols that are not there.

## What this adds

**Shared coordinate frames on Quest (CL-H).** Quest cannot relocalise a cloud anchor — the OpenXR session produces no camera image for the SIFT localiser and stubs cloud anchors outright — but Meta's spatial anchors already solve co-location. Driven entirely through OpenXR:

- create: `xrCreateSpatialAnchorFB` → enable STORABLE + SHARABLE → `xrShareSpacesMETA` to a group UUID
- join: `xrQuerySpacesFB` filtered by that UUID → enable LOCATABLE → locate

Group sharing rather than `XR_FB_spatial_entity_sharing`, and the choice is load-bearing: the FB path addresses recipients as `XrSpaceUserFB` handles built from Meta account ids, which only the Meta Platform SDK can supply and this repo does not carry. Group sharing takes an app-chosen UUID, so the flow stays inside OpenXR — and that UUID is also the co-location room key, so one identifier names the space, the frame and the channel room.

**The channel bridge.** `RVCCAColocationSession` existed in ReactVisionCCA with a reference server and nothing above could call it. `VROColocationSession` is the platform-neutral holder; Android reaches it through `Colocation_JNI`, iOS and visionOS through `VROColocationBridge`.

## Decisions worth reviewing

- **The channel is not hung off `VROARSession`.** It needs no AR session, only a room id and poses, and visionOS has no `VROARSession` at all — independence is what lets one implementation serve all three platforms.
- **`Colocation_JNI` binds to a plain Java class**, not a scene controller, for the same reason.
- **Peers cross JNI as one flat string.** This is polled several times a second; building an array per poll costs a local ref per field for no benefit.
- **`VROColocationBridge.h` is pure Objective-C**, because visionOS can only import headers that parse as such.
- **ReactVisionCCA stays optional.** Without it this compiles to a holder that reports unavailable, so an open-source build links and runs with no channel, exactly as it runs with no cloud anchors. Verified by compiling both ways.

## Verification

- `VROARSessionOpenXRSharedFrame.cpp`, `Colocation_JNI.cpp` and `VROColocationSession.cpp` compile with the NDK toolchain against the OpenXR 1.1.49 headers the build already links (`viroreact/build.gradle`).
- `VROColocationBridge.mm` compiles against both the iOS and visionOS SDKs.
- `ColocationSession.java` compiles.
- Added to the ViroKit and ViroKitVisionOS targets; the project still lints (`plutil`) and `xcodebuild -list` still reads it.

## Not done

**No device validation.** Nothing here has run on a Quest. The async event ordering and the already-enabled component paths are unexercised, and that is the main thing to be sceptical about in review.